### PR TITLE
Added static file support in golang-middleware

### DIFF
--- a/template/golang-middleware-armhf/Dockerfile
+++ b/template/golang-middleware-armhf/Dockerfile
@@ -28,6 +28,9 @@ WORKDIR /home/app
 
 COPY --from=build /go/src/handler/handler    .
 COPY --from=build /usr/bin/fwatchdog         .
+COPY --from=build /go/src/handler/function/  .
+
+RUN chown -R app /home/app
 
 USER app
 

--- a/template/golang-middleware/Dockerfile
+++ b/template/golang-middleware/Dockerfile
@@ -28,6 +28,9 @@ WORKDIR /home/app
 
 COPY --from=build /go/src/handler/handler    .
 COPY --from=build /usr/bin/fwatchdog         .
+COPY --from=build /go/src/handler/function/  .
+
+RUN chown -R app /home/app
 
 USER app
 


### PR DESCRIPTION
## Description
Added the command to copy static files along with chown to own the app folder. Fixes #7.

## How Has This Been Tested?
Tested by creating a function using the golang-middleware template and adding files other than handler.go. Then built the function and used docker run to start the container and manually verified the files were copied.

Not tested on ARM. No hardware to test with.

## How are existing users impacted? What migration steps/scripts do we need?


## Checklist:
I have:
- [ ] updated the documentation and/or roadmap (if required)
- [x] read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] signed-off my commits with `git commit -s`
- [ ] added unit tests