### PR TITLE
Ignore the SDK in vendor config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,3 @@
 build
 test
 test.yml
-
-template

--- a/template/golang-http-armhf/function/Gopkg.toml
+++ b/template/golang-http-armhf/function/Gopkg.toml
@@ -1,0 +1,7 @@
+# Gopkg.toml
+
+ignored = ["github.com/openfaas-incubator/go-function-sdk"]
+
+[prune]
+  go-tests = true
+  unused-packages = true

--- a/template/golang-http/function/Gopkg.toml
+++ b/template/golang-http/function/Gopkg.toml
@@ -1,0 +1,7 @@
+# Gopkg.toml
+
+ignored = ["github.com/openfaas-incubator/go-function-sdk"]
+
+[prune]
+  go-tests = true
+  unused-packages = true


### PR DESCRIPTION
Signed-off-by: Alex Ellis (VMware) <alexellis2@gmail.com>

## Description

Fix for #18 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

- fixes issue: #18 by ignoring the function SDK through
use of Gopkg.toml. If there are two nested vendor folders with
the same dependency it causes a build error.

Tested with a local build pairing with Michael Gasch

## How are existing users impacted? What migration steps/scripts do we need?

Users may need to apply the same fix if they have already generated functions or Gopkg.toml files.

## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [x] read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] signed-off my commits with `git commit -s`
- [ ] added unit tests
