### PR TITLE
Timeout should match value in environment

### DIFF
--- a/template/golang-http/main.go
+++ b/template/golang-http/main.go
@@ -5,6 +5,7 @@ import (
 	"io/ioutil"
 	"log"
 	"net/http"
+	"os"
 	"time"
 
 	"handler/function"
@@ -60,11 +61,21 @@ func makeRequestHandler() func(http.ResponseWriter, *http.Request) {
 func main() {
 	s := &http.Server{
 		Addr:           fmt.Sprintf(":%d", 8081),
-		ReadTimeout:    3 * time.Second,
-		WriteTimeout:   3 * time.Second,
+		ReadTimeout:    getDuration("write_timout", 10*time.Second),
+		WriteTimeout:   getDuration("read_timout", 10*time.Second),
 		MaxHeaderBytes: 1 << 20, // Max header of 1MB
 	}
 
 	http.HandleFunc("/", makeRequestHandler())
 	log.Fatal(s.ListenAndServe())
+}
+
+// getDuration returns a duration value from the environment or returns the default
+func getDuration(key string, defaultValue time.Duration) time.Duration {
+	result := defaultValue
+	if val := os.Getenv(key); val != "" {
+		parsed, _ := time.ParseDuration(val)
+		result = parsed
+	}
+	return result
 }


### PR DESCRIPTION
## Description
This change fixes the issue of the hard-coded timeout value. This fixes #9
I ran into this issue here: https://github.com/openfaas-incubator/of-watchdog/issues/50

This is not yet complete (must be duplicated 4x). This is what I needed to change to get my long running function to work and I am looking for feedback here.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I have tested this in my environment. See https://github.com/openfaas-incubator/of-watchdog/issues/50#issuecomment-465430595

## How are existing users impacted? What migration steps/scripts do we need?
Values set for "write_timeout" will be respected.

## Checklist:

I have:

- [x] updated the documentation and/or roadmap (if required)
- [x] read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [ ] signed-off my commits with `git commit -s`
- [ ] added unit tests
