### PR TITLE
Allow for customizing the read and write timeouts

### DIFF
--- a/template/golang-http-armhf/Dockerfile
+++ b/template/golang-http-armhf/Dockerfile
@@ -35,5 +35,7 @@ USER app
 ENV fprocess="./handler"
 ENV mode="http"
 ENV upstream_url="http://127.0.0.1:8082"
+ENV read_timeout="3s"
+ENV write_timeout="3s"
 
 CMD ["./fwatchdog"]

--- a/template/golang-http-armhf/main.go
+++ b/template/golang-http-armhf/main.go
@@ -5,6 +5,7 @@ import (
 	"io/ioutil"
 	"log"
 	"net/http"
+	"os"
 	"time"
 
 	"handler/function"
@@ -60,11 +61,19 @@ func makeRequestHandler() func(http.ResponseWriter, *http.Request) {
 func main() {
 	s := &http.Server{
 		Addr:           fmt.Sprintf(":%d", 8082),
-		ReadTimeout:    3 * time.Second,
-		WriteTimeout:   3 * time.Second,
+		ReadTimeout:    mustParseDuration(os.Getenv("read_timeout")),
+		WriteTimeout:   mustParseDuration(os.Getenv("write_timeout")),
 		MaxHeaderBytes: 1 << 20, // Max header of 1MB
 	}
 
 	http.HandleFunc("/", makeRequestHandler())
 	log.Fatal(s.ListenAndServe())
+}
+
+func mustParseDuration(v string) time.Duration {
+	d, err := time.ParseDuration(v)
+	if err != nil {
+		panic(err)
+	}
+	return d
 }

--- a/template/golang-http/Dockerfile
+++ b/template/golang-http/Dockerfile
@@ -35,5 +35,7 @@ USER app
 ENV fprocess="./handler"
 ENV mode="http"
 ENV upstream_url="http://127.0.0.1:8082"
+ENV read_timeout="3s"
+ENV write_timeout="3s"
 
 CMD ["./fwatchdog"]

--- a/template/golang-http/main.go
+++ b/template/golang-http/main.go
@@ -5,6 +5,7 @@ import (
 	"io/ioutil"
 	"log"
 	"net/http"
+	"os"
 	"time"
 
 	"handler/function"
@@ -60,11 +61,19 @@ func makeRequestHandler() func(http.ResponseWriter, *http.Request) {
 func main() {
 	s := &http.Server{
 		Addr:           fmt.Sprintf(":%d", 8082),
-		ReadTimeout:    3 * time.Second,
-		WriteTimeout:   3 * time.Second,
+		ReadTimeout:    mustParseDuration(os.Getenv("read_timeout")),
+		WriteTimeout:   mustParseDuration(os.Getenv("write_timeout")),
 		MaxHeaderBytes: 1 << 20, // Max header of 1MB
 	}
 
 	http.HandleFunc("/", makeRequestHandler())
 	log.Fatal(s.ListenAndServe())
+}
+
+func mustParseDuration(v string) time.Duration {
+	d, err := time.ParseDuration(v)
+	if err != nil {
+		panic(err)
+	}
+	return d
 }

--- a/template/golang-middleware-armhf/Dockerfile
+++ b/template/golang-middleware-armhf/Dockerfile
@@ -35,5 +35,7 @@ USER app
 ENV fprocess="./handler"
 ENV mode="http"
 ENV upstream_url="http://127.0.0.1:8082"
+ENV read_timeout="3s"
+ENV write_timeout="3s"
 
 CMD ["./fwatchdog"]

--- a/template/golang-middleware-armhf/main.go
+++ b/template/golang-middleware-armhf/main.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+	"os"
 	"time"
 
 	"handler/function"
@@ -13,11 +14,19 @@ import (
 func main() {
 	s := &http.Server{
 		Addr:           fmt.Sprintf(":%d", 8082),
-		ReadTimeout:    3 * time.Second,
-		WriteTimeout:   3 * time.Second,
+		ReadTimeout:    mustParseDuration(os.Getenv("read_timeout")),
+		WriteTimeout:   mustParseDuration(os.Getenv("write_timeout")),
 		MaxHeaderBytes: 1 << 20, // Max header of 1MB
 	}
 
 	http.HandleFunc("/", function.Handle)
 	log.Fatal(s.ListenAndServe())
+}
+
+func mustParseDuration(v string) time.Duration {
+	d, err := time.ParseDuration(v)
+	if err != nil {
+		panic(err)
+	}
+	return d
 }

--- a/template/golang-middleware/Dockerfile
+++ b/template/golang-middleware/Dockerfile
@@ -35,5 +35,7 @@ USER app
 ENV fprocess="./handler"
 ENV mode="http"
 ENV upstream_url="http://127.0.0.1:8082"
+ENV read_timeout="3s"
+ENV write_timeout="3s"
 
 CMD ["./fwatchdog"]

--- a/template/golang-middleware/main.go
+++ b/template/golang-middleware/main.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+	"os"
 	"time"
 
 	"handler/function"
@@ -13,11 +14,20 @@ import (
 func main() {
 	s := &http.Server{
 		Addr:           fmt.Sprintf(":%d", 8082),
-		ReadTimeout:    3 * time.Second,
-		WriteTimeout:   3 * time.Second,
+		Addr:           fmt.Sprintf(":%d", 8082),
+		ReadTimeout:    mustParseDuration(os.Getenv("read_timeout")),
+		WriteTimeout:   mustParseDuration(os.Getenv("write_timeout")),
 		MaxHeaderBytes: 1 << 20, // Max header of 1MB
 	}
 
 	http.HandleFunc("/", function.Handle)
 	log.Fatal(s.ListenAndServe())
+}
+
+func mustParseDuration(v string) time.Duration {
+	d, err := time.ParseDuration(v)
+	if err != nil {
+		panic(err)
+	}
+	return d
 }


### PR DESCRIPTION
## Description

Allows for setting the read and write timeouts using the `read_timeout` and `write_timeout` environment variables.

Closes #9.

## How Has This Been Tested?

I've tested this by setting the aforementioned values to `10s` (hence more than the default of `3s`) and executing a piece of code that takes a while to complete:

```
2019/06/12 15:56:23 stderr: 2019/06/12 15:56:23 entered Handle
(...)
2019/06/12 15:56:27 exited Handle
2019/06/12 15:56:27 POST / - 200 OK - ContentLength: 0
```

Before this change, I would get something like the following:

```
2019/06/12 15:01:03 stderr: 2019/06/12 15:01:03 entered Handle
(...)
2019/06/12 15:01:07 exited Handle
2019/06/12 15:01:07 Upstream HTTP request error: Post http://127.0.0.1:8082/: EOF
```

## How are existing users impacted? What migration steps/scripts do we need?

I am not really sure, since I am fairly new to OpenFAAS.

## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [x] read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] signed-off my commits with `git commit -s`
- [ ] added unit tests
