### PR TITLE
Read timeout values from env-vars

### DIFF
--- a/template/golang-http-armhf/main.go
+++ b/template/golang-http-armhf/main.go
@@ -5,6 +5,8 @@ import (
 	"io/ioutil"
 	"log"
 	"net/http"
+	"os"
+	"strconv"
 	"time"
 
 	"handler/function"
@@ -57,11 +59,29 @@ func makeRequestHandler() func(http.ResponseWriter, *http.Request) {
 	}
 }
 
+func parseIntOrDurationValue(val string, fallback time.Duration) time.Duration {
+	if len(val) > 0 {
+		parsedVal, parseErr := strconv.Atoi(val)
+		if parseErr == nil && parsedVal >= 0 {
+			return time.Duration(parsedVal) * time.Second
+		}
+	}
+
+	duration, durationErr := time.ParseDuration(val)
+	if durationErr != nil {
+		return fallback
+	}
+	return duration
+}
+
 func main() {
+	readTimeout := parseIntOrDurationValue(os.Getenv("read_timeout"), 10*time.Second)
+	writeTimeout := parseIntOrDurationValue(os.Getenv("write_timeout"), 10*time.Second)
+
 	s := &http.Server{
 		Addr:           fmt.Sprintf(":%d", 8082),
-		ReadTimeout:    3 * time.Second,
-		WriteTimeout:   3 * time.Second,
+		ReadTimeout:    readTimeout,
+		WriteTimeout:   writeTimeout,
 		MaxHeaderBytes: 1 << 20, // Max header of 1MB
 	}
 

--- a/template/golang-http/main.go
+++ b/template/golang-http/main.go
@@ -5,6 +5,8 @@ import (
 	"io/ioutil"
 	"log"
 	"net/http"
+	"os"
+	"strconv"
 	"time"
 
 	"handler/function"
@@ -57,11 +59,29 @@ func makeRequestHandler() func(http.ResponseWriter, *http.Request) {
 	}
 }
 
+func parseIntOrDurationValue(val string, fallback time.Duration) time.Duration {
+	if len(val) > 0 {
+		parsedVal, parseErr := strconv.Atoi(val)
+		if parseErr == nil && parsedVal >= 0 {
+			return time.Duration(parsedVal) * time.Second
+		}
+	}
+
+	duration, durationErr := time.ParseDuration(val)
+	if durationErr != nil {
+		return fallback
+	}
+	return duration
+}
+
 func main() {
+	readTimeout := parseIntOrDurationValue(os.Getenv("read_timeout"), 10*time.Second)
+	writeTimeout := parseIntOrDurationValue(os.Getenv("write_timeout"), 10*time.Second)
+
 	s := &http.Server{
 		Addr:           fmt.Sprintf(":%d", 8082),
-		ReadTimeout:    3 * time.Second,
-		WriteTimeout:   3 * time.Second,
+		ReadTimeout:    readTimeout,
+		WriteTimeout:   writeTimeout,
 		MaxHeaderBytes: 1 << 20, // Max header of 1MB
 	}
 

--- a/template/golang-middleware-armhf/main.go
+++ b/template/golang-middleware-armhf/main.go
@@ -4,17 +4,37 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+	"os"
+	"strconv"
 	"time"
 
 	"handler/function"
 	//"github.com/openfaas-incubator/golang-http-template/template/golang-middleware/function"
 )
 
+func parseIntOrDurationValue(val string, fallback time.Duration) time.Duration {
+	if len(val) > 0 {
+		parsedVal, parseErr := strconv.Atoi(val)
+		if parseErr == nil && parsedVal >= 0 {
+			return time.Duration(parsedVal) * time.Second
+		}
+	}
+
+	duration, durationErr := time.ParseDuration(val)
+	if durationErr != nil {
+		return fallback
+	}
+	return duration
+}
+
 func main() {
+	readTimeout := parseIntOrDurationValue(os.Getenv("read_timeout"), 10*time.Second)
+	writeTimeout := parseIntOrDurationValue(os.Getenv("write_timeout"), 10*time.Second)
+
 	s := &http.Server{
 		Addr:           fmt.Sprintf(":%d", 8082),
-		ReadTimeout:    3 * time.Second,
-		WriteTimeout:   3 * time.Second,
+		ReadTimeout:    readTimeout,
+		WriteTimeout:   writeTimeout,
 		MaxHeaderBytes: 1 << 20, // Max header of 1MB
 	}
 

--- a/template/golang-middleware/main.go
+++ b/template/golang-middleware/main.go
@@ -4,17 +4,37 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+	"os"
+	"strconv"
 	"time"
 
 	"handler/function"
 	//"github.com/openfaas-incubator/golang-http-template/template/golang-middleware/function"
 )
 
+func parseIntOrDurationValue(val string, fallback time.Duration) time.Duration {
+	if len(val) > 0 {
+		parsedVal, parseErr := strconv.Atoi(val)
+		if parseErr == nil && parsedVal >= 0 {
+			return time.Duration(parsedVal) * time.Second
+		}
+	}
+
+	duration, durationErr := time.ParseDuration(val)
+	if durationErr != nil {
+		return fallback
+	}
+	return duration
+}
+
 func main() {
+	readTimeout := parseIntOrDurationValue(os.Getenv("read_timeout"), 10*time.Second)
+	writeTimeout := parseIntOrDurationValue(os.Getenv("write_timeout"), 10*time.Second)
+
 	s := &http.Server{
 		Addr:           fmt.Sprintf(":%d", 8082),
-		ReadTimeout:    3 * time.Second,
-		WriteTimeout:   3 * time.Second,
+		ReadTimeout:    readTimeout,
+		WriteTimeout:   writeTimeout,
 		MaxHeaderBytes: 1 << 20, // Max header of 1MB
 	}
 


### PR DESCRIPTION
Signed-off-by: Alex Ellis <alexellis2@gmail.com>

## Description

Fixes: #20 

Closes: #22 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested by creating Golang-http and Golang-middleware functions with a 5s wait inside. These were then deployed to Docker Swarm and invoked. Previously they choked at 3s.

```go
package function

import (
	"fmt"
	"io/ioutil"
	"net/http"
	"time"
)

func Handle(w http.ResponseWriter, r *http.Request) {
	var input []byte

	if r.Body != nil {
		defer r.Body.Close()

		body, _ := ioutil.ReadAll(r.Body)

		input = body
	}

	time.Sleep(5 * time.Second)
	w.WriteHeader(http.StatusOK)
	w.Write([]byte(fmt.Sprintf("Nice sleep, input was: %s", string(input))))
}

```

```go
package function

import (
	"fmt"
	"github.com/openfaas-incubator/go-function-sdk"
	"net/http"

	"time"
)

// Handle a function invocation
func Handle(req handler.Request) (handler.Response, error) {
	var err error

	message := fmt.Sprintf("Nice sleep, input was: %s", string(req.Body))

	time.Sleep(5 * time.Second)

	return handler.Response{
		Body:       []byte(message),
		StatusCode: http.StatusOK,
	}, err
}

```

```bash
space-mini:golang-http-template alex$ time curl -d test http://127.0.0.1:8080/function
/golang-middleware1
Nice sleep, input was: test
real    0m5.023s
user    0m0.005s
sys     0m0.004s
space-mini:golang-http-template alex$ 

space-mini:golang-http-template alex$ time curl -d "test" http://127.0.0.1:8080/functi
on/golang-http1
Nice sleep, input was: test
real    0m5.021s
user    0m0.004s
sys     0m0.004s
space-mini:golang-http-template alex$ 
```

Setting the timeout value to 2s then gave a premature failure, as expected:

```yaml
version: 1.0
provider:
  name: openfaas
  gateway: http://127.0.0.1:8080
functions:
  golang-http1:
    lang: golang-http
    handler: ./golang-http1
    image: golang-http1:latest1
    environment:
      read_timeout: 2s
      write_timeout: 2s
```

The fail-back behaviour for legacy users / templates / docs of using an integer vs. Golang duration for timeouts is also now working as expected:

```yaml
version: 1.0
provider:
  name: openfaas
  gateway: http://127.0.0.1:8080
functions:
  golang-http1:
    lang: golang-http
    handler: ./golang-http1
    image: golang-http1:latest1
    environment:
      read_timeout: 10
      write_timeout: 10
```

Result:

```sh
space-mini:golang-http-template alex$ time curl -d "test" http://127.0.0.1:8080/functi
on/golang-http1
Nice sleep, input was: test
real    0m5.021s
user    0m0.004s
sys     0m0.004s
```

## How are existing users impacted? What migration steps/scripts do we need?

It should be a no-harm change. The default (10s) is larger than the previous 3s.

## Checklist:

I have:

- [x] updated the documentation and/or roadmap (if required)
- [x] read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] signed-off my commits with `git commit -s`
- [ ] added unit tests