### PR TITLE
Ensure querystring is copied over for the function

### DIFF
--- a/template/golang-http-armhf/main.go
+++ b/template/golang-http-armhf/main.go
@@ -31,9 +31,10 @@ func makeRequestHandler() func(http.ResponseWriter, *http.Request) {
 		}
 
 		req := handler.Request{
-			Body:   input,
-			Header: r.Header,
-			Method: r.Method,
+			Body:        input,
+			Header:      r.Header,
+			Method:      r.Method,
+			QueryString: r.URL.RawQuery,
 		}
 
 		result, resultErr := function.Handle(req)

--- a/template/golang-http/main.go
+++ b/template/golang-http/main.go
@@ -31,9 +31,10 @@ func makeRequestHandler() func(http.ResponseWriter, *http.Request) {
 		}
 
 		req := handler.Request{
-			Body:   input,
-			Header: r.Header,
-			Method: r.Method,
+			Body:        input,
+			Header:      r.Header,
+			Method:      r.Method,
+			QueryString: r.URL.RawQuery,
 		}
 
 		result, resultErr := function.Handle(req)


### PR DESCRIPTION
## Description
Fixes #25
Make the QueryString available within function.


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manually tested against the following function:

```go
package function

import (
	"github.com/openfaas-incubator/go-function-sdk"
)

// Handle a function invocation
func Handle(req handler.Request) (handler.Response, error) {
	return handler.Response{
		Body:       []byte(req.QueryString),
		StatusCode: http.StatusOK,
	}, err
}
```


## How are existing users impacted? What migration steps/scripts do we need?


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [x] read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] signed-off my commits with `git commit -s`
- [ ] added unit tests
