### PR TITLE
Update of-watchdog to 0.7.1

### DIFF
--- a/template/golang-http/Dockerfile
+++ b/template/golang-http/Dockerfile
@@ -1,4 +1,4 @@
-FROM openfaas/of-watchdog:0.5.3 as watchdog
+FROM openfaas/of-watchdog:0.7.1 as watchdog
 FROM golang:1.10.4-alpine3.8 as build
 
 ENV CGO_ENABLED=0

--- a/template/golang-middleware/Dockerfile
+++ b/template/golang-middleware/Dockerfile
@@ -1,4 +1,4 @@
-FROM openfaas/of-watchdog:0.5.3 as watchdog
+FROM openfaas/of-watchdog:0.7.1 as watchdog
 FROM golang:1.11-alpine3.10 as build
 
 ENV CGO_ENABLED=0


### PR DESCRIPTION
## Description
Updates the version of of-watchdog to latest 0.7.1
Largely includes changes for logging both from the watchdog itself and how logging is captured from the wrapped go process.

More detail about changes can be seen at the [releases of of-watchdog](https://github.com/openfaas-incubator/of-watchdog/releases)

## How Has This Been Tested?
I manually copied these templates into a new directory and generated and deployed two new functions on a Docker for Mac managed Kubernetes cluster.

### golang-http
```bash
faas-cli new --lang golang-http test-golang-http
# update the image name in the generated .yml file to `cconger/`
faas-cli up test-golang-http
faas-cli invoke test-golang-http
# Verify the proper input echoing behavior
faas-cli logs test-golang-http
# Verify the output of expected logs
```

**test-golang-http invocation**
```
Reading from STDIN - hit (Control + D) to stop.
test
Hello world, input was: test
```

**test-golang-http logs**
```
WARNING! Communication is not secure, please consider using HTTPS. Letsencrypt.org offers free SSL/TLS certificates.
2019-08-30T00:44:30Z Forking - ./handler []
2019-08-30T00:44:30Z 2019/08/30 00:44:30 Started logging stderr from function.
2019-08-30T00:44:30Z 2019/08/30 00:44:30 Started logging stdout from function.
2019-08-30T00:44:30Z 2019/08/30 00:44:30 OperationalMode: http
2019-08-30T00:44:30Z 2019/08/30 00:44:30 Timeouts: read: 10s, write: 10s hard: 10s.
2019-08-30T00:44:30Z 2019/08/30 00:44:30 Listening on port: 8080
2019-08-30T00:44:30Z 2019/08/30 00:44:30 Writing lock-file to: /tmp/.lock
2019-08-30T00:44:30Z 2019/08/30 00:44:30 Metrics listening on port: 8081
2019-08-30T00:45:01Z 2019/08/30 00:45:01 POST / - 200 OK - ContentLength: 29
```

### golang-middleware
```bash
faas-cli new --lang golang-middleware test-golang-middleware
# update the image name in the generated .yml file to `cconger/test-golang-middleware:latest`
faas-cli up test-golang-middleware
faas-cli invoke test-golang-middleware
# Verify the proper input echoing behavior
faas-cli logs test-golang-middleware --name=false --instance=false
# Verify the output of expected logs
```

**test-golang-middleware invocation**
```
Reading from STDIN - hit (Control + D) to stop.
test
Hello world, input was: test
```

**test-golang-middlware logs**
```
WARNING! Communication is not secure, please consider using HTTPS. Letsencrypt.org offers free SSL/TLS certificates.
2019-08-30T00:41:07Z Forking - ./handler []
2019-08-30T00:41:07Z 2019/08/30 00:41:07 Started logging stderr from function.
2019-08-30T00:41:07Z 2019/08/30 00:41:07 Started logging stdout from function.
2019-08-30T00:41:07Z 2019/08/30 00:41:07 OperationalMode: http
2019-08-30T00:41:07Z 2019/08/30 00:41:07 Timeouts: read: 10s, write: 10s hard: 10s.
2019-08-30T00:41:07Z 2019/08/30 00:41:07 Listening on port: 8080
2019-08-30T00:41:07Z 2019/08/30 00:41:07 Writing lock-file to: /tmp/.lock
2019-08-30T00:41:07Z 2019/08/30 00:41:07 Metrics listening on port: 8081
2019-08-30T00:41:18Z 2019/08/30 00:41:18 POST / - 200 OK - ContentLength: 29
```

## How are existing users impacted? What migration steps/scripts do we need?
Logging will be slightly different for new applications.  Log lines can now exceed 256 bytes when sent from the wrapped function process.  No mitigation steps seem likely.

## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [x] read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] signed-off my commits with `git commit -s`
- [ ] added unit tests
