### PR TITLE
Adds graceful shutdown for golang -middleware and -http

### DIFF
--- a/template/golang-http-armhf/.gitignore
+++ b/template/golang-http-armhf/.gitignore
@@ -1,0 +1,1 @@
+/handler

--- a/template/golang-http-armhf/Dockerfile
+++ b/template/golang-http-armhf/Dockerfile
@@ -1,4 +1,4 @@
-FROM openfaas/of-watchdog:0.7.3 as watchdog
+FROM openfaas/of-watchdog:0.7.6 as watchdog
 FROM golang:1.13-alpine3.11 as build
 
 RUN apk --no-cache add git

--- a/template/golang-http-armhf/main.go
+++ b/template/golang-http-armhf/main.go
@@ -1,18 +1,79 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"io/ioutil"
 	"log"
 	"net/http"
 	"os"
+	"os/signal"
 	"strconv"
+	"sync/atomic"
+	"syscall"
 	"time"
 
 	"handler/function"
-	// "github.com/alexellis/golang-http-template/template/golang-http/function"
+
 	handler "github.com/openfaas-incubator/go-function-sdk"
 )
+
+var (
+	acceptingConnections int32
+)
+
+const defaultTimeout = 10 * time.Second
+
+func main() {
+	readTimeout := parseIntOrDurationValue(os.Getenv("read_timeout"), defaultTimeout)
+	writeTimeout := parseIntOrDurationValue(os.Getenv("write_timeout"), defaultTimeout)
+
+	s := &http.Server{
+		Addr:           fmt.Sprintf(":%d", 8082),
+		ReadTimeout:    readTimeout,
+		WriteTimeout:   writeTimeout,
+		MaxHeaderBytes: 1 << 20, // Max header of 1MB
+	}
+
+	http.HandleFunc("/", makeRequestHandler())
+	listenUntilShutdown(s, writeTimeout)
+}
+
+func listenUntilShutdown(s *http.Server, shutdownTimeout time.Duration) {
+	idleConnsClosed := make(chan struct{})
+	go func() {
+		sig := make(chan os.Signal, 1)
+		signal.Notify(sig, syscall.SIGTERM)
+
+		<-sig
+
+		log.Printf("[entrypoint] SIGTERM received.. shutting down server in %s\n", shutdownTimeout.String())
+
+		<-time.Tick(shutdownTimeout)
+
+		if err := s.Shutdown(context.Background()); err != nil {
+			log.Printf("[entrypoint] Error in Shutdown: %v", err)
+		}
+
+		log.Printf("[entrypoint] No new connections allowed. Exiting in: %s\n", shutdownTimeout.String())
+
+		<-time.Tick(shutdownTimeout)
+
+		close(idleConnsClosed)
+	}()
+
+	// Run the HTTP server in a separate go-routine.
+	go func() {
+		if err := s.ListenAndServe(); err != http.ErrServerClosed {
+			log.Printf("[entrypoint] Error ListenAndServe: %v", err)
+			close(idleConnsClosed)
+		}
+	}()
+
+	atomic.StoreInt32(&acceptingConnections, 1)
+
+	<-idleConnsClosed
+}
 
 func makeRequestHandler() func(http.ResponseWriter, *http.Request) {
 	return func(w http.ResponseWriter, r *http.Request) {
@@ -73,19 +134,4 @@ func parseIntOrDurationValue(val string, fallback time.Duration) time.Duration {
 		return fallback
 	}
 	return duration
-}
-
-func main() {
-	readTimeout := parseIntOrDurationValue(os.Getenv("read_timeout"), 10*time.Second)
-	writeTimeout := parseIntOrDurationValue(os.Getenv("write_timeout"), 10*time.Second)
-
-	s := &http.Server{
-		Addr:           fmt.Sprintf(":%d", 8082),
-		ReadTimeout:    readTimeout,
-		WriteTimeout:   writeTimeout,
-		MaxHeaderBytes: 1 << 20, // Max header of 1MB
-	}
-
-	http.HandleFunc("/", makeRequestHandler())
-	log.Fatal(s.ListenAndServe())
 }

--- a/template/golang-http/.gitignore
+++ b/template/golang-http/.gitignore
@@ -1,0 +1,1 @@
+/handler

--- a/template/golang-http/Dockerfile
+++ b/template/golang-http/Dockerfile
@@ -1,4 +1,4 @@
-FROM openfaas/of-watchdog:0.7.3 as watchdog
+FROM openfaas/of-watchdog:0.7.6 as watchdog
 FROM golang:1.13-alpine3.11 as build
 
 RUN apk --no-cache add git

--- a/template/golang-http/main.go
+++ b/template/golang-http/main.go
@@ -1,18 +1,79 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"io/ioutil"
 	"log"
 	"net/http"
 	"os"
+	"os/signal"
 	"strconv"
+	"sync/atomic"
+	"syscall"
 	"time"
 
 	"handler/function"
-	// "github.com/alexellis/golang-http-template/template/golang-http/function"
+
 	handler "github.com/openfaas-incubator/go-function-sdk"
 )
+
+var (
+	acceptingConnections int32
+)
+
+const defaultTimeout = 10 * time.Second
+
+func main() {
+	readTimeout := parseIntOrDurationValue(os.Getenv("read_timeout"), defaultTimeout)
+	writeTimeout := parseIntOrDurationValue(os.Getenv("write_timeout"), defaultTimeout)
+
+	s := &http.Server{
+		Addr:           fmt.Sprintf(":%d", 8082),
+		ReadTimeout:    readTimeout,
+		WriteTimeout:   writeTimeout,
+		MaxHeaderBytes: 1 << 20, // Max header of 1MB
+	}
+
+	http.HandleFunc("/", makeRequestHandler())
+	listenUntilShutdown(s, writeTimeout)
+}
+
+func listenUntilShutdown(s *http.Server, shutdownTimeout time.Duration) {
+	idleConnsClosed := make(chan struct{})
+	go func() {
+		sig := make(chan os.Signal, 1)
+		signal.Notify(sig, syscall.SIGTERM)
+
+		<-sig
+
+		log.Printf("[entrypoint] SIGTERM received.. shutting down server in %s\n", shutdownTimeout.String())
+
+		<-time.Tick(shutdownTimeout)
+
+		if err := s.Shutdown(context.Background()); err != nil {
+			log.Printf("[entrypoint] Error in Shutdown: %v", err)
+		}
+
+		log.Printf("[entrypoint] No new connections allowed. Exiting in: %s\n", shutdownTimeout.String())
+
+		<-time.Tick(shutdownTimeout)
+
+		close(idleConnsClosed)
+	}()
+
+	// Run the HTTP server in a separate go-routine.
+	go func() {
+		if err := s.ListenAndServe(); err != http.ErrServerClosed {
+			log.Printf("[entrypoint] Error ListenAndServe: %v", err)
+			close(idleConnsClosed)
+		}
+	}()
+
+	atomic.StoreInt32(&acceptingConnections, 1)
+
+	<-idleConnsClosed
+}
 
 func makeRequestHandler() func(http.ResponseWriter, *http.Request) {
 	return func(w http.ResponseWriter, r *http.Request) {
@@ -73,19 +134,4 @@ func parseIntOrDurationValue(val string, fallback time.Duration) time.Duration {
 		return fallback
 	}
 	return duration
-}
-
-func main() {
-	readTimeout := parseIntOrDurationValue(os.Getenv("read_timeout"), 10*time.Second)
-	writeTimeout := parseIntOrDurationValue(os.Getenv("write_timeout"), 10*time.Second)
-
-	s := &http.Server{
-		Addr:           fmt.Sprintf(":%d", 8082),
-		ReadTimeout:    readTimeout,
-		WriteTimeout:   writeTimeout,
-		MaxHeaderBytes: 1 << 20, // Max header of 1MB
-	}
-
-	http.HandleFunc("/", makeRequestHandler())
-	log.Fatal(s.ListenAndServe())
 }

--- a/template/golang-middleware-armhf/.gitignore
+++ b/template/golang-middleware-armhf/.gitignore
@@ -1,0 +1,1 @@
+/handler

--- a/template/golang-middleware-armhf/Dockerfile
+++ b/template/golang-middleware-armhf/Dockerfile
@@ -1,4 +1,4 @@
-FROM openfaas/of-watchdog:0.7.3 as watchdog
+FROM openfaas/of-watchdog:0.7.6 as watchdog
 FROM golang:1.13-alpine3.11 as build
 
 RUN apk --no-cache add git

--- a/template/golang-middleware-armhf/main.go
+++ b/template/golang-middleware-armhf/main.go
@@ -1,16 +1,77 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"net/http"
 	"os"
+	"os/signal"
 	"strconv"
+	"sync/atomic"
+	"syscall"
 	"time"
 
 	"handler/function"
-	//"github.com/openfaas-incubator/golang-http-template/template/golang-middleware/function"
 )
+
+var (
+	acceptingConnections int32
+)
+
+const defaultTimeout = 10 * time.Second
+
+func main() {
+	readTimeout := parseIntOrDurationValue(os.Getenv("read_timeout"), defaultTimeout)
+	writeTimeout := parseIntOrDurationValue(os.Getenv("write_timeout"), defaultTimeout)
+
+	s := &http.Server{
+		Addr:           fmt.Sprintf(":%d", 8082),
+		ReadTimeout:    readTimeout,
+		WriteTimeout:   writeTimeout,
+		MaxHeaderBytes: 1 << 20, // Max header of 1MB
+	}
+
+	http.HandleFunc("/", function.Handle)
+
+	listenUntilShutdown(s, writeTimeout)
+}
+
+func listenUntilShutdown(s *http.Server, shutdownTimeout time.Duration) {
+	idleConnsClosed := make(chan struct{})
+	go func() {
+		sig := make(chan os.Signal, 1)
+		signal.Notify(sig, syscall.SIGTERM)
+
+		<-sig
+
+		log.Printf("[entrypoint] SIGTERM received.. shutting down server in %s\n", shutdownTimeout.String())
+
+		<-time.Tick(shutdownTimeout)
+
+		if err := s.Shutdown(context.Background()); err != nil {
+			log.Printf("[entrypoint] Error in Shutdown: %v", err)
+		}
+
+		log.Printf("[entrypoint] No new connections allowed. Exiting in: %s\n", shutdownTimeout.String())
+
+		<-time.Tick(shutdownTimeout)
+
+		close(idleConnsClosed)
+	}()
+
+	// Run the HTTP server in a separate go-routine.
+	go func() {
+		if err := s.ListenAndServe(); err != http.ErrServerClosed {
+			log.Printf("[entrypoint] Error ListenAndServe: %v", err)
+			close(idleConnsClosed)
+		}
+	}()
+
+	atomic.StoreInt32(&acceptingConnections, 1)
+
+	<-idleConnsClosed
+}
 
 func parseIntOrDurationValue(val string, fallback time.Duration) time.Duration {
 	if len(val) > 0 {
@@ -25,19 +86,4 @@ func parseIntOrDurationValue(val string, fallback time.Duration) time.Duration {
 		return fallback
 	}
 	return duration
-}
-
-func main() {
-	readTimeout := parseIntOrDurationValue(os.Getenv("read_timeout"), 10*time.Second)
-	writeTimeout := parseIntOrDurationValue(os.Getenv("write_timeout"), 10*time.Second)
-
-	s := &http.Server{
-		Addr:           fmt.Sprintf(":%d", 8082),
-		ReadTimeout:    readTimeout,
-		WriteTimeout:   writeTimeout,
-		MaxHeaderBytes: 1 << 20, // Max header of 1MB
-	}
-
-	http.HandleFunc("/", function.Handle)
-	log.Fatal(s.ListenAndServe())
 }

--- a/template/golang-middleware/.gitignore
+++ b/template/golang-middleware/.gitignore
@@ -1,0 +1,1 @@
+/handler

--- a/template/golang-middleware/Dockerfile
+++ b/template/golang-middleware/Dockerfile
@@ -1,4 +1,4 @@
-FROM openfaas/of-watchdog:0.7.3 as watchdog
+FROM openfaas/of-watchdog:0.7.6 as watchdog
 FROM golang:1.13-alpine3.11 as build
 
 RUN apk --no-cache add git

--- a/template/golang-middleware/main.go
+++ b/template/golang-middleware/main.go
@@ -1,16 +1,77 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"net/http"
 	"os"
+	"os/signal"
 	"strconv"
+	"sync/atomic"
+	"syscall"
 	"time"
 
 	"handler/function"
-	//"github.com/openfaas-incubator/golang-http-template/template/golang-middleware/function"
 )
+
+var (
+	acceptingConnections int32
+)
+
+const defaultTimeout = 10 * time.Second
+
+func main() {
+	readTimeout := parseIntOrDurationValue(os.Getenv("read_timeout"), defaultTimeout)
+	writeTimeout := parseIntOrDurationValue(os.Getenv("write_timeout"), defaultTimeout)
+
+	s := &http.Server{
+		Addr:           fmt.Sprintf(":%d", 8082),
+		ReadTimeout:    readTimeout,
+		WriteTimeout:   writeTimeout,
+		MaxHeaderBytes: 1 << 20, // Max header of 1MB
+	}
+
+	http.HandleFunc("/", function.Handle)
+
+	listenUntilShutdown(s, writeTimeout)
+}
+
+func listenUntilShutdown(s *http.Server, shutdownTimeout time.Duration) {
+	idleConnsClosed := make(chan struct{})
+	go func() {
+		sig := make(chan os.Signal, 1)
+		signal.Notify(sig, syscall.SIGTERM)
+
+		<-sig
+
+		log.Printf("[entrypoint] SIGTERM received.. shutting down server in %s\n", shutdownTimeout.String())
+
+		<-time.Tick(shutdownTimeout)
+
+		if err := s.Shutdown(context.Background()); err != nil {
+			log.Printf("[entrypoint] Error in Shutdown: %v", err)
+		}
+
+		log.Printf("[entrypoint] No new connections allowed. Exiting in: %s\n", shutdownTimeout.String())
+
+		<-time.Tick(shutdownTimeout)
+
+		close(idleConnsClosed)
+	}()
+
+	// Run the HTTP server in a separate go-routine.
+	go func() {
+		if err := s.ListenAndServe(); err != http.ErrServerClosed {
+			log.Printf("[entrypoint] Error ListenAndServe: %v", err)
+			close(idleConnsClosed)
+		}
+	}()
+
+	atomic.StoreInt32(&acceptingConnections, 1)
+
+	<-idleConnsClosed
+}
 
 func parseIntOrDurationValue(val string, fallback time.Duration) time.Duration {
 	if len(val) > 0 {
@@ -25,19 +86,4 @@ func parseIntOrDurationValue(val string, fallback time.Duration) time.Duration {
 		return fallback
 	}
 	return duration
-}
-
-func main() {
-	readTimeout := parseIntOrDurationValue(os.Getenv("read_timeout"), 10*time.Second)
-	writeTimeout := parseIntOrDurationValue(os.Getenv("write_timeout"), 10*time.Second)
-
-	s := &http.Server{
-		Addr:           fmt.Sprintf(":%d", 8082),
-		ReadTimeout:    readTimeout,
-		WriteTimeout:   writeTimeout,
-		MaxHeaderBytes: 1 << 20, // Max header of 1MB
-	}
-
-	http.HandleFunc("/", function.Handle)
-	log.Fatal(s.ListenAndServe())
 }


### PR DESCRIPTION
## Description

Adds graceful shutdown for golang -middleware and -http

Signed-off-by: Alex Ellis (OpenFaaS Ltd) <alexellis2@gmail.com>

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Closes: #35

Tested outside of a container, using kill -s TERM <PID> - it
worked as expected by waiting for N seconds.

## How are existing users impacted? What migration steps/scripts do we need?

Enhancement, users can rebuild to get this change.

<img width="1741" alt="Screenshot 2020-02-06 at 10 52 48" src="https://user-images.githubusercontent.com/6358735/73930826-1d95ad00-48cf-11ea-91f7-647ceba24bd9.png">
