### PR TITLE
Update to of-watchdog 0.7.7 and the docs

### DIFF
--- a/template/golang-http-armhf/Dockerfile
+++ b/template/golang-http-armhf/Dockerfile
@@ -1,4 +1,4 @@
-FROM openfaas/of-watchdog:0.7.6 as watchdog
+FROM openfaas/of-watchdog:0.7.7 as watchdog
 FROM golang:1.13-alpine3.11 as build
 
 RUN apk --no-cache add git

--- a/template/golang-http/Dockerfile
+++ b/template/golang-http/Dockerfile
@@ -1,4 +1,4 @@
-FROM openfaas/of-watchdog:0.7.6 as watchdog
+FROM openfaas/of-watchdog:0.7.7 as watchdog
 FROM golang:1.13-alpine3.11 as build
 
 RUN apk --no-cache add git

--- a/template/golang-middleware-armhf/Dockerfile
+++ b/template/golang-middleware-armhf/Dockerfile
@@ -1,4 +1,4 @@
-FROM openfaas/of-watchdog:0.7.6 as watchdog
+FROM openfaas/of-watchdog:0.7.7 as watchdog
 FROM golang:1.13-alpine3.11 as build
 
 RUN apk --no-cache add git

--- a/template/golang-middleware/Dockerfile
+++ b/template/golang-middleware/Dockerfile
@@ -1,4 +1,4 @@
-FROM openfaas/of-watchdog:0.7.6 as watchdog
+FROM openfaas/of-watchdog:0.7.7 as watchdog
 FROM golang:1.13-alpine3.11 as build
 
 RUN apk --no-cache add git


### PR DESCRIPTION
## Description
- Update to the latest of-watchdog 0.7.7, ensuring the request context
  is propagated correctly
- Add examples of how to use the context to abort requests early

Resolve #40 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I manually tested this with the example from the issue https://github.com/openfaas-incubator/golang-http-template/issues/40#issuecomment-609381468

![image](https://user-images.githubusercontent.com/891889/78471302-84e5a700-7730-11ea-81b9-3977e97e8028.png)


## How are existing users impacted? What migration steps/scripts do we need?


## Checklist:

I have:

- [x] updated the documentation and/or roadmap (if required)
- [x] read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] signed-off my commits with `git commit -s`
- [ ] added unit tests
