### PR TITLE
Feature: move to scratch Docker image (WIP)

### DIFF
--- a/template/golang-http/Dockerfile
+++ b/template/golang-http/Dockerfile
@@ -1,7 +1,18 @@
-FROM openfaas/of-watchdog:0.8.0 as watchdog
-FROM golang:1.13-alpine3.11 as build
+FROM openfaas/of-watchdog:0.8.0 AS watchdog
 
-RUN apk --no-cache add git
+#
+# ---
+#
+
+FROM golang:1.15.0-alpine3.12 AS build
+
+ARG UID=1000
+ARG GID=1000
+
+# ignore non-pinned packages
+# hadolint ignore=DL3018
+RUN apk --no-cache add git tzdata ca-certificates \
+    && addgroup -g "$GID" -S app && adduser -u "$UID" -S -D -H -g app app
 
 ENV CGO_ENABLED=0
 
@@ -13,33 +24,45 @@ WORKDIR /go/src/handler
 COPY . .
 
 # Run a gofmt and exclude all vendored code.
+# hadolint ignore=SC2046
 RUN test -z "$(gofmt -l $(find . -type f -name '*.go' -not -path "./vendor/*" -not -path "./function/vendor/*"))" || { echo "Run \"gofmt -s -w\" on your Golang code"; exit 1; }
 
 ARG GO111MODULE="off"
 ARG GOPROXY=""
 
-RUN go build --ldflags "-s -w" -a -installsuffix cgo -o handler .
+RUN go build --ldflags '-s -w -extldflags "-static"' -a -installsuffix cgo -o handler .
 RUN go test handler/function/... -cover
 
-FROM alpine:3.11
-# Add non root user and certs
-RUN apk --no-cache add ca-certificates \
-    && addgroup -S app && adduser -S -g app app \
-    && mkdir -p /home/app \
-    && chown app /home/app
+#
+# ---
+#
 
+FROM scratch
+
+# run out of /home/app by default
 WORKDIR /home/app
 
+# add-in our timezone data file
+COPY --from=build /usr/share/zoneinfo /usr/share/zoneinfo
+
+# add-in our unprivileged user
+COPY --from=build /etc/passwd /etc/group /etc/shadow /etc/
+
+# add-in our ca certificates
+COPY --from=build /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
+
+# from now on, run as the unprivileged user
+USER app
+
+# copy-in our stuff
 COPY --from=build /go/src/handler/handler    .
 COPY --from=build /usr/bin/fwatchdog         .
 COPY --from=build /go/src/handler/function/  .
 
-RUN chown -R app /home/app
-
-USER app
-
+# set our variables
 ENV fprocess="./handler"
 ENV mode="http"
 ENV upstream_url="http://127.0.0.1:8082"
 
+# run our watchdog in the end
 CMD ["./fwatchdog"]


### PR DESCRIPTION
## Description
This fixes https://github.com/openfaas-incubator/golang-http-template/issues/45

- Use empty scratch image
- Do away with useless home directory
- Use newer Go and alpine linux versions
- Linted Dockerfile with hadolint
- Statically build Go binaries
- Set static user/group ids for easier debugging/mapping
