### PR TITLE
Update Go version to 1.16 for the images

### DIFF
--- a/README.md
+++ b/README.md
@@ -394,7 +394,7 @@ This replacement is handled gracefully by the template at build time and your lo
 
 ##### Go sub-modules
 
-For this example you will need to be using Go 1.13 or newer and Go modules, enable this via `faas-cli build --build-arg GO111MODULE=on`.
+For this example you will need to be using Go 1.16 or newer and Go modules, enable this via `faas-cli build --build-arg GO111MODULE=on`.
 
 Imagine you have a package which you want to store outside of the `handler.go` file, it's another middleware which can perform an echo of the user's input.
 

--- a/template/golang-http/Dockerfile
+++ b/template/golang-http/Dockerfile
@@ -1,5 +1,5 @@
 FROM --platform=${TARGETPLATFORM:-linux/amd64} ghcr.io/openfaas/of-watchdog:0.8.4 as watchdog
-FROM --platform=${BUILDPLATFORM:-linux/amd64} golang:1.15-alpine3.13 as build
+FROM --platform=${BUILDPLATFORM:-linux/amd64} golang:1.16-alpine3.13 as build
 
 ARG TARGETPLATFORM
 ARG BUILDPLATFORM

--- a/template/golang-http/go.mod
+++ b/template/golang-http/go.mod
@@ -1,6 +1,6 @@
 module handler
 
-go 1.15
+go 1.16
 
 replace handler/function => ./function
 

--- a/template/golang-http/template.yml
+++ b/template/golang-http/template.yml
@@ -1,7 +1,7 @@
 language: golang-http
 fprocess: ./handler
 welcome_message: |
-  You have created a new function which uses Golang 1.13.
+  You have created a new function which uses Golang 1.16.
 
   To include third-party dependencies, use Go modules and use
   "--build-arg GO111MODULE=on" with faas-cli build or configure this  

--- a/template/golang-middleware/Dockerfile
+++ b/template/golang-middleware/Dockerfile
@@ -1,5 +1,5 @@
 FROM --platform=${TARGETPLATFORM:-linux/amd64} ghcr.io/openfaas/of-watchdog:0.8.4 as watchdog
-FROM --platform=${BUILDPLATFORM:-linux/amd64} golang:1.15-alpine3.13 as build
+FROM --platform=${BUILDPLATFORM:-linux/amd64} golang:1.16-alpine3.13 as build
 
 ARG TARGETPLATFORM
 ARG BUILDPLATFORM

--- a/template/golang-middleware/go.mod
+++ b/template/golang-middleware/go.mod
@@ -1,5 +1,5 @@
 module handler
 
-go 1.15
+go 1.16
 
 replace handler/function => ./function

--- a/template/golang-middleware/template.yml
+++ b/template/golang-middleware/template.yml
@@ -1,7 +1,7 @@
 language: golang-middleware
 fprocess: ./handler
 welcome_message: |
-  You have created a new function which uses Golang 1.13.
+  You have created a new function which uses Golang 1.16.
 
   To include third-party dependencies, use Go modules and use
   "--build-arg GO111MODULE=on" with faas-cli build or configure this  


### PR DESCRIPTION
We need to bump up Go version to 1.16 for images to provide better
compatibility. At the time of this writing latest Go version is 1.17 and
latest alpine is 3.14

Signed-off-by: F. Talha Altınel <talhaaltinel@hotmail.com>

## Description
Update Go version from 1.15 to 1.16

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Impossible to test on every machine.

## How are existing users impacted? What migration steps/scripts do we need?
Version notes can be found here but I think migration is very minimal 
- https://golang.org/doc/go1.16

## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [X] read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [X] signed-off my commits with `git commit -s`
- [ ] added unit tests
