### PR TITLE
Bump to Go 1.17(latest stable) and alpine images to 3.14(latest stable)

### DIFF
--- a/template/golang-http/Dockerfile
+++ b/template/golang-http/Dockerfile
@@ -1,5 +1,5 @@
 FROM --platform=${TARGETPLATFORM:-linux/amd64} ghcr.io/openfaas/of-watchdog:0.8.4 as watchdog
-FROM --platform=${BUILDPLATFORM:-linux/amd64} golang:1.15-alpine3.13 as build
+FROM --platform=${BUILDPLATFORM:-linux/amd64} golang:1.17-alpine3.14 as build
 
 ARG TARGETPLATFORM
 ARG BUILDPLATFORM
@@ -37,7 +37,7 @@ WORKDIR /go/src/handler
 RUN CGO_ENABLED=${CGO_ENABLED} GOOS=${TARGETOS} GOARCH=${TARGETARCH} \
     go build --ldflags "-s -w" -a -installsuffix cgo -o handler .
 
-FROM --platform=${TARGETPLATFORM:-linux/amd64} alpine:3.13
+FROM --platform=${TARGETPLATFORM:-linux/amd64} alpine:3.14
 # Add non root user and certs
 RUN apk --no-cache add ca-certificates \
     && addgroup -S app && adduser -S -g app app

--- a/template/golang-http/go.mod
+++ b/template/golang-http/go.mod
@@ -1,6 +1,6 @@
 module handler
 
-go 1.15
+go 1.17
 
 replace handler/function => ./function
 

--- a/template/golang-http/template.yml
+++ b/template/golang-http/template.yml
@@ -1,7 +1,7 @@
 language: golang-http
 fprocess: ./handler
 welcome_message: |
-  You have created a new function which uses Go 1.15.
+  You have created a new function which uses Go 1.17
 
   To include third-party dependencies, use Go modules and use
   "--build-arg GO111MODULE=on" with faas-cli build or configure this  

--- a/template/golang-middleware/Dockerfile
+++ b/template/golang-middleware/Dockerfile
@@ -1,5 +1,5 @@
 FROM --platform=${TARGETPLATFORM:-linux/amd64} ghcr.io/openfaas/of-watchdog:0.8.4 as watchdog
-FROM --platform=${BUILDPLATFORM:-linux/amd64} golang:1.15-alpine3.13 as build
+FROM --platform=${BUILDPLATFORM:-linux/amd64} golang:1.17-alpine3.14 as build
 
 ARG TARGETPLATFORM
 ARG BUILDPLATFORM
@@ -36,7 +36,7 @@ WORKDIR /go/src/handler
 RUN CGO_ENABLED=${CGO_ENABLED} GOOS=${TARGETOS} GOARCH=${TARGETARCH} \
     go build --ldflags "-s -w" -a -installsuffix cgo -o handler .
 
-FROM --platform=${TARGETPLATFORM:-linux/amd64} alpine:3.13
+FROM --platform=${TARGETPLATFORM:-linux/amd64} alpine:3.14
 # Add non root user and certs
 RUN apk --no-cache add ca-certificates \
     && addgroup -S app && adduser -S -g app app

--- a/template/golang-middleware/go.mod
+++ b/template/golang-middleware/go.mod
@@ -1,5 +1,5 @@
 module handler
 
-go 1.15
+go 1.17
 
 replace handler/function => ./function

--- a/template/golang-middleware/template.yml
+++ b/template/golang-middleware/template.yml
@@ -1,7 +1,7 @@
 language: golang-middleware
 fprocess: ./handler
 welcome_message: |
-  You have created a new function which uses Go 1.15.
+  You have created a new function which uses Go 1.17
 
   To include third-party dependencies, use Go modules and use
   "--build-arg GO111MODULE=on" with faas-cli build or configure this  


### PR DESCRIPTION
After I did some testing on my Pi machine, I realized this is the latest
stable version to run these templates.

Signed-off-by: F. Talha Altınel <talhaaltinel@hotmail.com>

## Description
Update to the most crucial templates which are mainly used(mostly requested by many) in Go development for http REST APIs. After some consideration. I decided to close 1.16 because 1.18 is already on its way in 5 months. 1.17 has already reached its stability and openfaas should take advantage of it.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manually downloaded faasd through hack.sh and tried on rpi 400 (arm64 systems as well as amd64 on cloud instances)


## How are existing users impacted? What migration steps/scripts do we need?
Dunno, shouldn't be too hard to migrate from 1.15 to 1.17

## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [X] read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [X] signed-off my commits with `git commit -s`
- [ ] added unit tests
