### PR TITLE
Allow for shorter graceful shutdown

### DIFF
--- a/template/golang-middleware/main.go
+++ b/template/golang-middleware/main.go
@@ -24,6 +24,7 @@ const defaultTimeout = 10 * time.Second
 func main() {
 	readTimeout := parseIntOrDurationValue(os.Getenv("read_timeout"), defaultTimeout)
 	writeTimeout := parseIntOrDurationValue(os.Getenv("write_timeout"), defaultTimeout)
+	healthInterval := parseIntOrDurationValue(os.Getenv("healthcheck_interval"), writeTimeout)
 
 	s := &http.Server{
 		Addr:           fmt.Sprintf(":%d", 8082),
@@ -34,7 +35,7 @@ func main() {
 
 	http.HandleFunc("/", function.Handle)
 
-	listenUntilShutdown(s, writeTimeout)
+	listenUntilShutdown(s, healthInterval)
 }
 
 func listenUntilShutdown(s *http.Server, shutdownTimeout time.Duration) {
@@ -45,17 +46,14 @@ func listenUntilShutdown(s *http.Server, shutdownTimeout time.Duration) {
 
 		<-sig
 
-		log.Printf("[entrypoint] SIGTERM received.. shutting down server in %s\n", shutdownTimeout.String())
-
+		log.Printf("[entrypoint] SIGTERM: no connections in: %s", shutdownTimeout.String())
 		<-time.Tick(shutdownTimeout)
 
 		if err := s.Shutdown(context.Background()); err != nil {
 			log.Printf("[entrypoint] Error in Shutdown: %v", err)
 		}
 
-		log.Printf("[entrypoint] No new connections allowed. Exiting in: %s\n", shutdownTimeout.String())
-
-		<-time.Tick(shutdownTimeout)
+		log.Printf("[entrypoint] Exiting")
 
 		close(idleConnsClosed)
 	}()


### PR DESCRIPTION
Signed-off-by: Alex Ellis (OpenFaaS Ltd) <alexellis2@gmail.com>

## Description

Allow for shorter graceful shutdown

## How Has This Been Tested?

The healthcheck_interval env-var allows a user to specify a
shorter time before shutting down the HTTP server to new
connections.

This change has been tested upstream in the of-watchdog which
wraps this template.

## How are existing users impacted? What migration steps/scripts do we need?


The default behaviour is to continue to use the write_timeout
for a safe shutdown duration.

