### PR TITLE
default go module to on

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,8 @@ The two templates are equivalent with `golang-http` using a structured request/r
 
 You can manage dependencies in one of the following ways:
 
-* To use Go modules without vendoring, add `--build-arg GO111MODULE=on` to `faas-cli up`, you can also use `--build-arg GOPROXY=https://` if you want to use your own mirror for the modules
-* You can also Go modules with vendoring, run `go mod vendor` in your function folder and add `--build-arg GO111MODULE=on` to `faas-cli up`
+* To use Go modules without vendoring, the default already is set `GO111MODULE=on` but you also can make that explicity by adding `--build-arg GO111MODULE=on` to `faas-cli up`, you can also use `--build-arg GOPROXY=https://` if you want to use your own mirror for the modules
+* You can also Go modules with vendoring, run `go mod vendor` in your function folder and add `--build-arg GO111MODULE=off` to `faas-cli up`
 * For traditional vendoring with `dep` give no argument, or add `--build-arg GO111MODULE=off` to `faas-cli up`
 
 ## 1.0 golang-http
@@ -394,8 +394,6 @@ This replacement is handled gracefully by the template at build time and your lo
 
 ##### Go sub-modules
 
-For this example you will need to be using Go 1.13 or newer and Go modules, enable this via `faas-cli build --build-arg GO111MODULE=on`.
-
 Imagine you have a package which you want to store outside of the `handler.go` file, it's another middleware which can perform an echo of the user's input.
 
 ```Golang
@@ -439,3 +437,5 @@ func Handle(w http.ResponseWriter, r *http.Request) {
 	handlers.Echo(w, r)
 }
 ```
+
+If you have any vendor private dependency, you can disable the Go module via `faas-cli build --build-arg GO111MODULE=off`.

--- a/template/golang-http/template.yml
+++ b/template/golang-http/template.yml
@@ -3,8 +3,8 @@ fprocess: ./handler
 welcome_message: |
   You have created a new function which uses Go 1.16.
 
-  To include third-party dependencies, use Go modules and use
-  "--build-arg GO111MODULE=on" with faas-cli build or configure this  
+  To disable the go module, for private vendor code, please use
+  "--build-arg GO111MODULE=off" with faas-cli build or configure this
   via your stack.yml file.
 
   See more: https://docs.openfaas.com/cli/templates/

--- a/template/golang-middleware/Dockerfile
+++ b/template/golang-middleware/Dockerfile
@@ -17,7 +17,7 @@ RUN mkdir -p /go/src/handler
 WORKDIR /go/src/handler
 COPY . .
 
-ARG GO111MODULE="off"
+ARG GO111MODULE="on"
 ARG GOPROXY=""
 ARG GOFLAGS=""
 ARG DEBUG=0

--- a/template/golang-middleware/template.yml
+++ b/template/golang-middleware/template.yml
@@ -3,8 +3,8 @@ fprocess: ./handler
 welcome_message: |
   You have created a new function which uses Go 1.16.
 
-  To include third-party dependencies, use Go modules and use
-  "--build-arg GO111MODULE=on" with faas-cli build or configure this  
+  To disable the go module, for private vendor code, please use
+  "--build-arg GO111MODULE=off" with faas-cli build or configure this
   via your stack.yml file.
 
   See more: https://docs.openfaas.com/cli/templates/


### PR DESCRIPTION

## Description
default golang template to always download go module

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## How are existing users impacted? What migration steps/scripts do we need?

Building with no `build arg` and `go modules` should be `on`:
<details>

```shell
$ faas-cli build -f go-fn.yml
[0] > Building go-fn.
Clearing temporary build folder: ./build/go-fn/
Preparing: ./go-fn/ build/go-fn/function
Building: ctadeu/go-fn:latest with golang-http template. Please wait..
#2 [internal] load .dockerignore
#2 sha256:a5e45c5df94404234c0baa0fee5efd2ae0f2a957279d634e6321faff1ca3fd05
#2 transferring context:
#2 transferring context: 102B done
#2 ...

#1 [internal] load build definition from Dockerfile
#1 sha256:a8a9a143cae18ed8b505e2247c3246e0715c5da99d63cf57f80be3bcc4a5b7fd
#1 transferring dockerfile: 1.79kB done
#1 DONE 0.7s

#2 [internal] load .dockerignore
#2 sha256:a5e45c5df94404234c0baa0fee5efd2ae0f2a957279d634e6321faff1ca3fd05
#2 DONE 0.7s

#5 [internal] load metadata for docker.io/library/golang:1.16-alpine3.14
#5 sha256:4a716074dac10b53ba887ab004950f58baa9821eb3a4567be4126dca3b85ec25
#5 ...

#6 [auth] library/alpine:pull token for registry-1.docker.io
#6 sha256:0f6c3d51e6e18aca35ad739f5be6718722721bea4d4c914551fc50eeb313b474
#6 DONE 0.0s

#7 [auth] library/golang:pull token for registry-1.docker.io
#7 sha256:fb8bf95368f1681ca523e8300a0f88e95cf5dc9ca424a5a31e37dd129be5ce35
#7 DONE 0.0s

#4 [internal] load metadata for ghcr.io/openfaas/of-watchdog:0.9.0
#4 sha256:7a8111554b004441d4044bf0e3f592721766dec21a081daa32e01737262bacbc
#4 DONE 2.3s

#3 [internal] load metadata for docker.io/library/alpine:3.14
#3 sha256:af035606328a1ce217c0e290353f888d2ee03ed437bef601e11d9cc421fbbb67
#3 DONE 2.2s

#5 [internal] load metadata for docker.io/library/golang:1.16-alpine3.14
#5 sha256:4a716074dac10b53ba887ab004950f58baa9821eb3a4567be4126dca3b85ec25
#5 DONE 3.4s

#8 [stage-2 1/7] FROM docker.io/library/alpine:3.14@sha256:e1c082e3d3c45cccac829840a25941e679c25d438cc8412c2fa221cf1a824e6a
#8 sha256:22a19783a224a512c16cb61f0b28672bc354a6259258c154c780b5687dd99c4c
#8 DONE 0.0s

#12 [build  1/13] FROM docker.io/library/golang:1.16-alpine3.14@sha256:05df7ff684a2cb06aa207be14a78918cbc3285ed3b965974979e575d59de1c11
#12 sha256:2d1d768a87ae02aff813b70f34f32cc0e2cfe80efae1f08663f2fb81103c20ef
#12 DONE 0.0s

#14 [watchdog 1/1] FROM ghcr.io/openfaas/of-watchdog:0.9.0@sha256:96f16f420e9bda2fc8bc3b16e3abb5670badf62a7ea441435ff799b9613576e0
#14 sha256:79e45dcbab58e1c4babe76c8106eae956fd9c81fe5c4b19161ccf2f3e6a20e32
#14 DONE 0.0s

#19 [internal] load build context
#19 sha256:c6423fd6349e48b87bac0aca9e72472ab91810aeffdb6f4922284d41c7b6d778
#19 transferring context: 11.31kB done
#19 DONE 0.4s

#14 [watchdog 1/1] FROM ghcr.io/openfaas/of-watchdog:0.9.0@sha256:96f16f420e9bda2fc8bc3b16e3abb5670badf62a7ea441435ff799b9613576e0
#14 sha256:79e45dcbab58e1c4babe76c8106eae956fd9c81fe5c4b19161ccf2f3e6a20e32
#14 resolve ghcr.io/openfaas/of-watchdog:0.9.0@sha256:96f16f420e9bda2fc8bc3b16e3abb5670badf62a7ea441435ff799b9613576e0
#14 resolve ghcr.io/openfaas/of-watchdog:0.9.0@sha256:96f16f420e9bda2fc8bc3b16e3abb5670badf62a7ea441435ff799b9613576e0 0.2s done
#14 sha256:a223dc8c8e56d2ecd858f810dde711aebe7b215fdca66b088856e378df3cfb4c 528B / 528B done
#14 sha256:cf5514ecab7d4761624ac59d4159d9d86b96433d2932975d69737f9e93e8f563 1.16kB / 1.16kB done
#14 sha256:96f16f420e9bda2fc8bc3b16e3abb5670badf62a7ea441435ff799b9613576e0 1.08kB / 1.08kB done
#14 sha256:3e19094a9bc7531e1d64a005ac047f800cc875257a319d823f47c12004572207 0B / 3.27MB 0.2s
#14 sha256:3e19094a9bc7531e1d64a005ac047f800cc875257a319d823f47c12004572207 2.10MB / 3.27MB 0.6s
#14 extracting sha256:3e19094a9bc7531e1d64a005ac047f800cc875257a319d823f47c12004572207
#14 sha256:3e19094a9bc7531e1d64a005ac047f800cc875257a319d823f47c12004572207 3.27MB / 3.27MB 0.7s done
#14 extracting sha256:3e19094a9bc7531e1d64a005ac047f800cc875257a319d823f47c12004572207 0.4s done
#14 DONE 2.1s

#12 [build  1/13] FROM docker.io/library/golang:1.16-alpine3.14@sha256:05df7ff684a2cb06aa207be14a78918cbc3285ed3b965974979e575d59de1c11
#12 sha256:2d1d768a87ae02aff813b70f34f32cc0e2cfe80efae1f08663f2fb81103c20ef
#12 resolve docker.io/library/golang:1.16-alpine3.14@sha256:05df7ff684a2cb06aa207be14a78918cbc3285ed3b965974979e575d59de1c11
#12 resolve docker.io/library/golang:1.16-alpine3.14@sha256:05df7ff684a2cb06aa207be14a78918cbc3285ed3b965974979e575d59de1c11 0.2s done
#12 sha256:05df7ff684a2cb06aa207be14a78918cbc3285ed3b965974979e575d59de1c11 1.65kB / 1.65kB done
#12 sha256:45db38b5fc06a5fa18f18dec784dfcc60e7140676b7f9e4039768b54b9d4223e 1.36kB / 1.36kB done
#12 sha256:1b35785aa3c4f2f78a5ad5252332114f43bb07a438d9cccc153517ea8f7d1198 5.08kB / 5.08kB done
#12 sha256:31adcdaf11c89113a810db23d523e549d634d7de695a72b0ce98a1f912101262 0B / 281.51kB 0.2s
#12 sha256:23d1c9dd6ab7b181a04d66bcea471e9fcc97cdc39152ce413098373887a7e0d2 0B / 105.80MB 0.4s
#12 sha256:b8b176561691ea11cfe541f3ee363a3aa67e3649eb3273bea62ebeea713eaecd 0B / 154B 0.5s
#12 extracting sha256:31adcdaf11c89113a810db23d523e549d634d7de695a72b0ce98a1f912101262
#12 sha256:31adcdaf11c89113a810db23d523e549d634d7de695a72b0ce98a1f912101262 281.51kB / 281.51kB 0.5s done
#12 sha256:23d1c9dd6ab7b181a04d66bcea471e9fcc97cdc39152ce413098373887a7e0d2 6.29MB / 105.80MB 0.8s
#12 sha256:b8b176561691ea11cfe541f3ee363a3aa67e3649eb3273bea62ebeea713eaecd 154B / 154B 0.8s
#12 sha256:36803fd6ed32d2fbeb27157ae8bd9eac927a87d33ede687fc8c596fb1432e948 0B / 156B 0.8s
#12 sha256:b8b176561691ea11cfe541f3ee363a3aa67e3649eb3273bea62ebeea713eaecd 154B / 154B 0.8s done
#12 extracting sha256:31adcdaf11c89113a810db23d523e549d634d7de695a72b0ce98a1f912101262 0.3s done
#12 sha256:36803fd6ed32d2fbeb27157ae8bd9eac927a87d33ede687fc8c596fb1432e948 156B / 156B 0.9s
#12 sha256:23d1c9dd6ab7b181a04d66bcea471e9fcc97cdc39152ce413098373887a7e0d2 13.63MB / 105.80MB 1.1s
#12 sha256:36803fd6ed32d2fbeb27157ae8bd9eac927a87d33ede687fc8c596fb1432e948 156B / 156B 1.0s done
#12 extracting sha256:b8b176561691ea11cfe541f3ee363a3aa67e3649eb3273bea62ebeea713eaecd done
#12 sha256:23d1c9dd6ab7b181a04d66bcea471e9fcc97cdc39152ce413098373887a7e0d2 23.07MB / 105.80MB 1.5s
#12 sha256:23d1c9dd6ab7b181a04d66bcea471e9fcc97cdc39152ce413098373887a7e0d2 30.41MB / 105.80MB 1.7s
#12 sha256:23d1c9dd6ab7b181a04d66bcea471e9fcc97cdc39152ce413098373887a7e0d2 36.70MB / 105.80MB 2.1s
#12 sha256:23d1c9dd6ab7b181a04d66bcea471e9fcc97cdc39152ce413098373887a7e0d2 44.04MB / 105.80MB 2.4s
#12 sha256:23d1c9dd6ab7b181a04d66bcea471e9fcc97cdc39152ce413098373887a7e0d2 53.48MB / 105.80MB 2.8s
#12 sha256:23d1c9dd6ab7b181a04d66bcea471e9fcc97cdc39152ce413098373887a7e0d2 61.87MB / 105.80MB 3.1s
#12 sha256:23d1c9dd6ab7b181a04d66bcea471e9fcc97cdc39152ce413098373887a7e0d2 70.25MB / 105.80MB 3.4s
#12 sha256:23d1c9dd6ab7b181a04d66bcea471e9fcc97cdc39152ce413098373887a7e0d2 79.69MB / 105.80MB 3.7s
#12 sha256:23d1c9dd6ab7b181a04d66bcea471e9fcc97cdc39152ce413098373887a7e0d2 88.08MB / 105.80MB 4.0s
#12 sha256:23d1c9dd6ab7b181a04d66bcea471e9fcc97cdc39152ce413098373887a7e0d2 94.37MB / 105.80MB 4.3s
#12 sha256:23d1c9dd6ab7b181a04d66bcea471e9fcc97cdc39152ce413098373887a7e0d2 102.29MB / 105.80MB 4.6s
#12 sha256:23d1c9dd6ab7b181a04d66bcea471e9fcc97cdc39152ce413098373887a7e0d2 105.80MB / 105.80MB 4.8s done
#12 extracting sha256:23d1c9dd6ab7b181a04d66bcea471e9fcc97cdc39152ce413098373887a7e0d2
#12 extracting sha256:23d1c9dd6ab7b181a04d66bcea471e9fcc97cdc39152ce413098373887a7e0d2 5.1s
#12 extracting sha256:23d1c9dd6ab7b181a04d66bcea471e9fcc97cdc39152ce413098373887a7e0d2 10.3s
#12 extracting sha256:23d1c9dd6ab7b181a04d66bcea471e9fcc97cdc39152ce413098373887a7e0d2 11.9s done
#12 extracting sha256:36803fd6ed32d2fbeb27157ae8bd9eac927a87d33ede687fc8c596fb1432e948
#12 extracting sha256:36803fd6ed32d2fbeb27157ae8bd9eac927a87d33ede687fc8c596fb1432e948 done
#12 DONE 20.0s

#13 [build  2/13] RUN apk --no-cache add git
#13 sha256:aadeb081dc345bd787adffb8aed55e058313e886498b321035c71526ee8a13a1
#13 0.978 fetch https://dl-cdn.alpinelinux.org/alpine/v3.14/main/x86_64/APKINDEX.tar.gz
#13 2.081 fetch https://dl-cdn.alpinelinux.org/alpine/v3.14/community/x86_64/APKINDEX.tar.gz
#13 2.688 (1/6) Installing brotli-libs (1.0.9-r5)
#13 2.824 (2/6) Installing nghttp2-libs (1.43.0-r0)
#13 2.941 (3/6) Installing libcurl (7.79.1-r0)
#13 3.068 (4/6) Installing expat (2.4.1-r0)
#13 3.186 (5/6) Installing pcre2 (10.36-r0)
#13 3.313 (6/6) Installing git (2.32.0-r0)
#13 3.726 Executing busybox-1.33.1-r3.trigger
#13 3.743 OK: 19 MiB in 21 packages
#13 DONE 4.3s

#15 [build  3/13] COPY --from=watchdog /fwatchdog /usr/bin/fwatchdog
#15 sha256:f37d94a37464dd0be64ca2bb473127bd09f83801cc2db3c9b5519f474fb0badd
#15 DONE 0.9s

#16 [build  4/13] RUN chmod +x /usr/bin/fwatchdog
#16 sha256:2942f0cfba5d2072919d1e7dd4867558d9da1f98e74f7bd92840076c9f792f69
#16 DONE 1.6s

#17 [build  5/13] RUN mkdir -p /go/src/handler
#17 sha256:0f44b8ad6315464f6b692ce830638b3416bece8c677bb5f7e8f2d3ed7e252e5e
#17 DONE 1.6s

#18 [build  6/13] WORKDIR /go/src/handler
#18 sha256:94b3bde17a629f2739d9eb2bc1d1f006516fb63897212965425190f045ef12b8
#18 DONE 0.8s

#20 [build  7/13] COPY . .
#20 sha256:4b1fe95d19dfcfdb9be8fc1b68740bab05fd203ca2cac4dfc571faff6116ebf0
#20 DONE 0.7s

#21 [build  8/13] RUN sh modules-cleanup.sh
#21 sha256:7bd3c1fe8272dbae2ef947c2be72b11651ccd455140da645f7a33f2ccf9ce141
#21 1.182 vendor not found
#21 1.182 cleaning up go.mod
#21 1.265 cleanup local replace statements
#21 1.282 no vendor found, skipping modules.txt cleanup
#21 DONE 1.7s

#22 [build  9/13] RUN test -z "$(gofmt -l $(find . -type f -name '*.go' -not -path "./vendor/*" -not -path "./function/vendor/*"))" || { echo "Run "gofmt -s -w" on your Golang code"; exit 1; }
#22 sha256:c2cdfc8412d3a8fca5467624554077ebf8d0d81571e397ae4dae6ca42808c3fe
#22 DONE 1.6s

#23 [build 10/13] WORKDIR /go/src/handler/function
#23 sha256:5f393a1b0822be0344e6b8fcc5d9b449ac8e41ae0a0b75405a3667d2dce5764e
#23 DONE 0.7s

#24 [build 11/13] RUN GOOS=linux GOARCH=amd64 go test ./... -cover
#24 sha256:4a758dad335a8bf703fd0ce2a32eb0001ac462aa19dc89ba50689ad14c74e1e2
#24 1.967 go: downloading github.com/openfaas/templates-sdk v0.0.0-20200723110415-a699ec277c12
#24 12.71 ?     handler/function        [no test files]
#24 DONE 13.2s

#25 [build 12/13] WORKDIR /go/src/handler
#25 sha256:1d4eeac6fa47119daf7ee74632b04020f6da611d27b00e8437797a84e514e13a
#25 DONE 0.8s

#26 [build 13/13] RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64     go build --ldflags "-s -w" -a -installsuffix cgo -o handler .
#26 sha256:48223c1639fda2d12a0c8b7296090962823f9ab48047a49263e948f85c7656d0
#26 DONE 21.8s

#9 [stage-2 2/7] RUN apk --no-cache add ca-certificates     && addgroup -S app && adduser -S -g app app
#9 sha256:c3914ed5d013c25590c0b5813a69b5f6513aab586ee24d8a09610306d29fa841
#9 CACHED

#10 [stage-2 3/7] RUN mkdir -p /home/app     && chown app /home/app
#10 sha256:acf6de984056836415c95488cc28c31d454825db21908bb29a245244c7831197
#10 CACHED

#11 [stage-2 4/7] WORKDIR /home/app
#11 sha256:a5f52ff0e4c5e51598a9a9ebe0bae30e5e3e9caac0c203788cf2a9bcb478a204
#11 CACHED

#27 [stage-2 5/7] COPY --from=build --chown=app /go/src/handler/handler    .
#27 sha256:0babeb9fadf728e9b02c74cb2cedbf42389867f7b6e963d2e93a57720e883889
#27 DONE 0.6s

#28 [stage-2 6/7] COPY --from=build --chown=app /usr/bin/fwatchdog         .
#28 sha256:83c1f9d7a36d91e720126e0f7528993f90edc1c02c6433ff6b1474b2a0f3d7c2
#28 DONE 0.9s

#29 [stage-2 7/7] COPY --from=build --chown=app /go/src/handler/function/  .
#29 sha256:7141c55784ca82802841fd6c06b15e21a25e443954c1813c770d0c9d87bbf398
#29 DONE 0.8s

#30 exporting to image
#30 sha256:e8c613e07b0b7ff33893b694f7759a10d42e180f2b4dc349fb57dc6b71dcab00
#30 exporting layers
#30 exporting layers 1.0s done
#30 writing image sha256:7d38ce753e392f62feb88a94a6ef07facd62d010de15336ef868f0b709de71e4 0.0s done
#30 naming to docker.io/ctadeu/go-fn:latest 0.0s done
#30 DONE 1.2s

Use 'docker scan' to run Snyk tests against images to find vulnerabilities and learn how to fix them
Image: ctadeu/go-fn:latest built.
[0] < Building go-fn done in 83.18s.
[0] Worker done.

Total build time: 83.18s


```

</details>

Building with no `build arg --build-arg GO111MODULE=off` and `go modules` should be `off` and use the vendor:

<details>

```shell
$ faas-cli build -f go-fn.yml --build-arg GO111MODULE=off
[0] > Building go-fn.
Clearing temporary build folder: ./build/go-fn/
Preparing: ./go-fn/ build/go-fn/function
Building: ctadeu/go-fn:latest with golang-http template. Please wait..
#1 [internal] load build definition from Dockerfile
#1 sha256:f8d45454847230df97a2b9726681add9323d54d04869b5378e20a709262c1eb9
#1 transferring dockerfile: 1.79kB done
#1 DONE 0.6s

#2 [internal] load .dockerignore
#2 sha256:882de979dca7a76cf9bfaaa5ade4942287d8b291747eebb400716de1f267b137
#2 transferring context: 102B done
#2 DONE 0.7s

#5 [internal] load metadata for docker.io/library/alpine:3.14
#5 sha256:af035606328a1ce217c0e290353f888d2ee03ed437bef601e11d9cc421fbbb67
#5 DONE 1.2s

#4 [internal] load metadata for docker.io/library/golang:1.16-alpine3.14
#4 sha256:4a716074dac10b53ba887ab004950f58baa9821eb3a4567be4126dca3b85ec25
#4 DONE 2.2s

#3 [internal] load metadata for ghcr.io/openfaas/of-watchdog:0.9.0
#3 sha256:7a8111554b004441d4044bf0e3f592721766dec21a081daa32e01737262bacbc
#3 DONE 2.2s

#10 [build  1/13] FROM docker.io/library/golang:1.16-alpine3.14@sha256:05df7ff684a2cb06aa207be14a78918cbc3285ed3b965974979e575d59de1c11
#10 sha256:2d1d768a87ae02aff813b70f34f32cc0e2cfe80efae1f08663f2fb81103c20ef
#10 DONE 0.0s

#6 [stage-2 1/7] FROM docker.io/library/alpine:3.14@sha256:e1c082e3d3c45cccac829840a25941e679c25d438cc8412c2fa221cf1a824e6a
#6 sha256:22a19783a224a512c16cb61f0b28672bc354a6259258c154c780b5687dd99c4c
#6 DONE 0.0s

#12 [watchdog 1/1] FROM ghcr.io/openfaas/of-watchdog:0.9.0@sha256:96f16f420e9bda2fc8bc3b16e3abb5670badf62a7ea441435ff799b9613576e0
#12 sha256:79e45dcbab58e1c4babe76c8106eae956fd9c81fe5c4b19161ccf2f3e6a20e32
#12 DONE 0.0s

#17 [internal] load build context
#17 sha256:b052e7de75afd0c8876aefbf9addb497b2ef4a694ac84123ea99dfe56ff80816
#17 transferring context: 15.56kB 0.0s done
#17 DONE 0.4s

#12 [watchdog 1/1] FROM ghcr.io/openfaas/of-watchdog:0.9.0@sha256:96f16f420e9bda2fc8bc3b16e3abb5670badf62a7ea441435ff799b9613576e0
#12 sha256:79e45dcbab58e1c4babe76c8106eae956fd9c81fe5c4b19161ccf2f3e6a20e32
#12 resolve ghcr.io/openfaas/of-watchdog:0.9.0@sha256:96f16f420e9bda2fc8bc3b16e3abb5670badf62a7ea441435ff799b9613576e0
#12 resolve ghcr.io/openfaas/of-watchdog:0.9.0@sha256:96f16f420e9bda2fc8bc3b16e3abb5670badf62a7ea441435ff799b9613576e0 0.2s done
#12 sha256:a223dc8c8e56d2ecd858f810dde711aebe7b215fdca66b088856e378df3cfb4c 528B / 528B done
#12 sha256:cf5514ecab7d4761624ac59d4159d9d86b96433d2932975d69737f9e93e8f563 1.16kB / 1.16kB done
#12 sha256:96f16f420e9bda2fc8bc3b16e3abb5670badf62a7ea441435ff799b9613576e0 1.08kB / 1.08kB done
#12 sha256:3e19094a9bc7531e1d64a005ac047f800cc875257a319d823f47c12004572207 0B / 3.27MB 0.2s
#12 sha256:3e19094a9bc7531e1d64a005ac047f800cc875257a319d823f47c12004572207 1.05MB / 3.27MB 0.6s
#12 sha256:3e19094a9bc7531e1d64a005ac047f800cc875257a319d823f47c12004572207 3.27MB / 3.27MB 0.7s
#12 sha256:3e19094a9bc7531e1d64a005ac047f800cc875257a319d823f47c12004572207 3.27MB / 3.27MB 0.7s done
#12 extracting sha256:3e19094a9bc7531e1d64a005ac047f800cc875257a319d823f47c12004572207 0.1s
#12 extracting sha256:3e19094a9bc7531e1d64a005ac047f800cc875257a319d823f47c12004572207 0.4s done
#12 DONE 2.1s

#10 [build  1/13] FROM docker.io/library/golang:1.16-alpine3.14@sha256:05df7ff684a2cb06aa207be14a78918cbc3285ed3b965974979e575d59de1c11
#10 sha256:2d1d768a87ae02aff813b70f34f32cc0e2cfe80efae1f08663f2fb81103c20ef
#10 resolve docker.io/library/golang:1.16-alpine3.14@sha256:05df7ff684a2cb06aa207be14a78918cbc3285ed3b965974979e575d59de1c11
#10 resolve docker.io/library/golang:1.16-alpine3.14@sha256:05df7ff684a2cb06aa207be14a78918cbc3285ed3b965974979e575d59de1c11 0.2s done
#10 sha256:05df7ff684a2cb06aa207be14a78918cbc3285ed3b965974979e575d59de1c11 1.65kB / 1.65kB done
#10 sha256:45db38b5fc06a5fa18f18dec784dfcc60e7140676b7f9e4039768b54b9d4223e 1.36kB / 1.36kB done
#10 sha256:1b35785aa3c4f2f78a5ad5252332114f43bb07a438d9cccc153517ea8f7d1198 5.08kB / 5.08kB done
#10 sha256:23d1c9dd6ab7b181a04d66bcea471e9fcc97cdc39152ce413098373887a7e0d2 0B / 105.80MB 0.2s
#10 sha256:b8b176561691ea11cfe541f3ee363a3aa67e3649eb3273bea62ebeea713eaecd 0B / 154B 0.4s
#10 sha256:31adcdaf11c89113a810db23d523e549d634d7de695a72b0ce98a1f912101262 0B / 281.51kB 0.5s
#10 sha256:23d1c9dd6ab7b181a04d66bcea471e9fcc97cdc39152ce413098373887a7e0d2 6.29MB / 105.80MB 0.6s
#10 sha256:b8b176561691ea11cfe541f3ee363a3aa67e3649eb3273bea62ebeea713eaecd 154B / 154B 0.6s
#10 sha256:b8b176561691ea11cfe541f3ee363a3aa67e3649eb3273bea62ebeea713eaecd 154B / 154B 0.6s done
#10 sha256:31adcdaf11c89113a810db23d523e549d634d7de695a72b0ce98a1f912101262 281.51kB / 281.51kB 0.8s
#10 sha256:36803fd6ed32d2fbeb27157ae8bd9eac927a87d33ede687fc8c596fb1432e948 0B / 156B 0.8s
#10 extracting sha256:31adcdaf11c89113a810db23d523e549d634d7de695a72b0ce98a1f912101262
#10 sha256:23d1c9dd6ab7b181a04d66bcea471e9fcc97cdc39152ce413098373887a7e0d2 14.68MB / 105.80MB 0.9s
#10 sha256:31adcdaf11c89113a810db23d523e549d634d7de695a72b0ce98a1f912101262 281.51kB / 281.51kB 0.8s done
#10 sha256:23d1c9dd6ab7b181a04d66bcea471e9fcc97cdc39152ce413098373887a7e0d2 20.97MB / 105.80MB 1.1s
#10 sha256:36803fd6ed32d2fbeb27157ae8bd9eac927a87d33ede687fc8c596fb1432e948 156B / 156B 1.0s done
#10 extracting sha256:31adcdaf11c89113a810db23d523e549d634d7de695a72b0ce98a1f912101262 0.3s done
#10 sha256:23d1c9dd6ab7b181a04d66bcea471e9fcc97cdc39152ce413098373887a7e0d2 28.31MB / 105.80MB 1.5s
#10 extracting sha256:b8b176561691ea11cfe541f3ee363a3aa67e3649eb3273bea62ebeea713eaecd 0.0s done
#10 sha256:23d1c9dd6ab7b181a04d66bcea471e9fcc97cdc39152ce413098373887a7e0d2 35.65MB / 105.80MB 1.7s
#10 sha256:23d1c9dd6ab7b181a04d66bcea471e9fcc97cdc39152ce413098373887a7e0d2 44.04MB / 105.80MB 2.0s
#10 sha256:23d1c9dd6ab7b181a04d66bcea471e9fcc97cdc39152ce413098373887a7e0d2 50.33MB / 105.80MB 2.2s
#10 sha256:23d1c9dd6ab7b181a04d66bcea471e9fcc97cdc39152ce413098373887a7e0d2 60.82MB / 105.80MB 2.6s
#10 sha256:23d1c9dd6ab7b181a04d66bcea471e9fcc97cdc39152ce413098373887a7e0d2 72.35MB / 105.80MB 3.0s
#10 sha256:23d1c9dd6ab7b181a04d66bcea471e9fcc97cdc39152ce413098373887a7e0d2 78.64MB / 105.80MB 3.2s
#10 sha256:23d1c9dd6ab7b181a04d66bcea471e9fcc97cdc39152ce413098373887a7e0d2 85.98MB / 105.80MB 3.5s
#10 sha256:23d1c9dd6ab7b181a04d66bcea471e9fcc97cdc39152ce413098373887a7e0d2 94.37MB / 105.80MB 3.8s
#10 sha256:23d1c9dd6ab7b181a04d66bcea471e9fcc97cdc39152ce413098373887a7e0d2 100.66MB / 105.80MB 4.0s
#10 sha256:23d1c9dd6ab7b181a04d66bcea471e9fcc97cdc39152ce413098373887a7e0d2 105.80MB / 105.80MB 4.2s done
#10 extracting sha256:23d1c9dd6ab7b181a04d66bcea471e9fcc97cdc39152ce413098373887a7e0d2
#10 extracting sha256:23d1c9dd6ab7b181a04d66bcea471e9fcc97cdc39152ce413098373887a7e0d2 5.1s
#10 extracting sha256:23d1c9dd6ab7b181a04d66bcea471e9fcc97cdc39152ce413098373887a7e0d2 10.4s
#10 extracting sha256:23d1c9dd6ab7b181a04d66bcea471e9fcc97cdc39152ce413098373887a7e0d2 12.0s done
#10 extracting sha256:36803fd6ed32d2fbeb27157ae8bd9eac927a87d33ede687fc8c596fb1432e948
#10 extracting sha256:36803fd6ed32d2fbeb27157ae8bd9eac927a87d33ede687fc8c596fb1432e948 done
#10 DONE 19.8s

#11 [build  2/13] RUN apk --no-cache add git
#11 sha256:aadeb081dc345bd787adffb8aed55e058313e886498b321035c71526ee8a13a1
#11 0.983 fetch https://dl-cdn.alpinelinux.org/alpine/v3.14/main/x86_64/APKINDEX.tar.gz
#11 2.111 fetch https://dl-cdn.alpinelinux.org/alpine/v3.14/community/x86_64/APKINDEX.tar.gz
#11 2.771 (1/6) Installing brotli-libs (1.0.9-r5)
#11 2.908 (2/6) Installing nghttp2-libs (1.43.0-r0)
#11 3.027 (3/6) Installing libcurl (7.79.1-r0)
#11 3.154 (4/6) Installing expat (2.4.1-r0)
#11 3.280 (5/6) Installing pcre2 (10.36-r0)
#11 3.411 (6/6) Installing git (2.32.0-r0)
#11 3.858 Executing busybox-1.33.1-r3.trigger
#11 3.875 OK: 19 MiB in 21 packages
#11 DONE 4.5s

#13 [build  3/13] COPY --from=watchdog /fwatchdog /usr/bin/fwatchdog
#13 sha256:f37d94a37464dd0be64ca2bb473127bd09f83801cc2db3c9b5519f474fb0badd
#13 DONE 1.1s

#14 [build  4/13] RUN chmod +x /usr/bin/fwatchdog
#14 sha256:2942f0cfba5d2072919d1e7dd4867558d9da1f98e74f7bd92840076c9f792f69
#14 DONE 1.6s

#15 [build  5/13] RUN mkdir -p /go/src/handler
#15 sha256:0f44b8ad6315464f6b692ce830638b3416bece8c677bb5f7e8f2d3ed7e252e5e
#15 DONE 1.6s

#16 [build  6/13] WORKDIR /go/src/handler
#16 sha256:94b3bde17a629f2739d9eb2bc1d1f006516fb63897212965425190f045ef12b8
#16 DONE 0.8s

#18 [build  7/13] COPY . .
#18 sha256:2b7ae1fb739f4fab74f9a47fd57be4838c5474cc41d13e8ff7d4b972cb6294e6
#18 DONE 0.8s

#19 [build  8/13] RUN sh modules-cleanup.sh
#19 sha256:1aca4575cb5b5efc3148d0c7bef6c1c65f3ada23715f2ccef3e49027ef0b78fe
#19 1.172 moving function vendor
#19 1.179 modules disabled, skipping go.mod cleanup
#19 1.179 modules disabled, skipping modules.txt cleanup
#19 DONE 1.5s

#20 [build  9/13] RUN test -z "$(gofmt -l $(find . -type f -name '*.go' -not -path "./vendor/*" -not -path "./function/vendor/*"))" || { echo "Run "gofmt -s -w" on your Golang code"; exit 1; }
#20 sha256:f808514b09d0042c2e2063168b9e5e5a52c2d94683c264c6305f949cb3c3166b
#20 DONE 1.6s

#21 [build 10/13] WORKDIR /go/src/handler/function
#21 sha256:e619a594daf0ef42f6b348a9b858dbcfd8a81143920044a1dd1072e1faa9ed9c
#21 DONE 0.7s

#22 [build 11/13] RUN GOOS=linux GOARCH=amd64 go test ./... -cover
#22 sha256:492f5124f30e0e5b699e21637b3a4349a29bc45234a95ad46f81c7aec38dea07
#22 11.13 ?     handler/function        [no test files]
#22 DONE 11.7s

#23 [build 12/13] WORKDIR /go/src/handler
#23 sha256:3d614ffd4e8590154b7dcfa13e046980f1831664d4f7f6c89fd002691a8161dc
#23 DONE 0.8s

#24 [build 13/13] RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64     go build --ldflags "-s -w" -a -installsuffix cgo -o handler .
#24 sha256:de2877023711ed24fffca828f2a5a72fc62f6ddc6016e15ceb02bc1392309684
#24 DONE 20.6s

#7 [stage-2 2/7] RUN apk --no-cache add ca-certificates     && addgroup -S app && adduser -S -g app app
#7 sha256:c3914ed5d013c25590c0b5813a69b5f6513aab586ee24d8a09610306d29fa841
#7 CACHED

#8 [stage-2 3/7] RUN mkdir -p /home/app     && chown app /home/app
#8 sha256:acf6de984056836415c95488cc28c31d454825db21908bb29a245244c7831197
#8 CACHED

#9 [stage-2 4/7] WORKDIR /home/app
#9 sha256:a5f52ff0e4c5e51598a9a9ebe0bae30e5e3e9caac0c203788cf2a9bcb478a204
#9 CACHED

#25 [stage-2 5/7] COPY --from=build --chown=app /go/src/handler/handler    .
#25 sha256:e1dce634854f89d2fa31b601b1f3202a6cc770b286124d3fcfccceb9951e0d8c
#25 DONE 0.7s

#26 [stage-2 6/7] COPY --from=build --chown=app /usr/bin/fwatchdog         .
#26 sha256:ae3ae47e2509e7afe398363e0cd200f90794832c38e702d1a048fcc2476e44ab
#26 DONE 0.8s

#27 [stage-2 7/7] COPY --from=build --chown=app /go/src/handler/function/  .
#27 sha256:b3754fcf6f93bdabe616f06e244788cbca5a294b8a9add6ecaa23766590f3998
#27 DONE 0.8s

#28 exporting to image
#28 sha256:e8c613e07b0b7ff33893b694f7759a10d42e180f2b4dc349fb57dc6b71dcab00
#28 exporting layers
#28 exporting layers 1.0s done
#28 writing image sha256:75c4e92f20425b4a16446b1a76f142bfc80b48814b22eff6327a4f5a924a83ab 0.0s done
#28 naming to docker.io/ctadeu/go-fn:latest 0.0s done
#28 DONE 1.2s

Use 'docker scan' to run Snyk tests against images to find vulnerabilities and learn how to fix them
Image: ctadeu/go-fn:latest built.
[0] < Building go-fn done in 79.51s.
[0] Worker done.

Total build time: 79.51s
```

</details>
## Checklist:

I have:

- [x] updated the documentation and/or roadmap (if required)
- [x] read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] signed-off my commits with `git commit -s`
- [ ] added unit tests

Fixes #62 