### PR TITLE
 Use of-watchdog 0.9.3 to suppress custom health check logging messages

### DIFF
--- a/template/golang-http/Dockerfile
+++ b/template/golang-http/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=${TARGETPLATFORM:-linux/amd64} ghcr.io/openfaas/of-watchdog:0.9.2 as watchdog
+FROM --platform=${TARGETPLATFORM:-linux/amd64} ghcr.io/openfaas/of-watchdog:0.9.3 as watchdog
 FROM --platform=${BUILDPLATFORM:-linux/amd64} golang:1.16-alpine3.14 as build
 
 ARG TARGETPLATFORM

--- a/template/golang-middleware/Dockerfile
+++ b/template/golang-middleware/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=${TARGETPLATFORM:-linux/amd64} ghcr.io/openfaas/of-watchdog:0.9.2 as watchdog
+FROM --platform=${TARGETPLATFORM:-linux/amd64} ghcr.io/openfaas/of-watchdog:0.9.3 as watchdog
 FROM --platform=${BUILDPLATFORM:-linux/amd64} golang:1.16-alpine3.14 as build
 
 ARG TARGETPLATFORM


### PR DESCRIPTION
Signed-off-by: Nitishkumar Singh <nitishkumarsingh71@gmail.com>

## Description
Use of-watchdog 0.9.3 to suppress custom health check logging messages

Closes #65 
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

 1. Made changes into template
 2. Created new function with from local templates using `faas-cli new golang-http-test --lang golang-http`
 3. Build function `faas-cli build -f ./golang-http-test.yml`
 4. Deploy function `faas-cli deploy -f ./golang-http-test.yml`
 5. Invoke function 



## How are existing users impacted? What migration steps/scripts do we need?
Only custom health check logs are being removed from logs. Ideally it should not impact any user, unless they are monitoring health check logs

## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [x] read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] signed-off my commits with `git commit -s`
- [ ] added unit tests
