### PR TITLE
Switch to io from ioutil to read body

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,7 +213,7 @@ package function
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"os"
 )
@@ -225,7 +225,7 @@ func Handle(w http.ResponseWriter, r *http.Request) {
 		defer r.Body.Close()
 
 		// read request payload
-		reqBody, err := ioutil.ReadAll(r.Body)
+		reqBody, err := io.ReadAll(r.Body)
 
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
@@ -268,7 +268,7 @@ package function
 import (
 	"database/sql"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strings"
 	_ "github.com/go-sql-driver/mysql"
@@ -298,7 +298,7 @@ func Handle(w http.ResponseWriter, r *http.Request) {
 		defer r.Body.Close()
 
 		// read request payload
-		body, err := ioutil.ReadAll(r.Body)
+		body, err := io.ReadAll(r.Body)
 
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
@@ -400,14 +400,14 @@ Imagine you have a package which you want to store outside of the `handler.go` f
 package handlers
 
 import (
-	"io/ioutil"
+	"io"
 	"net/http"
 )
 
 func Echo(w http.ResponseWriter, r *http.Request) {
 	if r.Body != nil {
 		defer r.Body.Close()
-		b, _ := ioutil.ReadAll(r.Body)
+		b, _ := io.ReadAll(r.Body)
 		w.Write(b)
 	}
 }

--- a/template/golang-http/Dockerfile
+++ b/template/golang-http/Dockerfile
@@ -17,7 +17,7 @@ RUN mkdir -p /go/src/handler
 WORKDIR /go/src/handler
 COPY . .
 
-ARG GO111MODULE="off"
+ARG GO111MODULE="on"
 ARG GOPROXY=""
 ARG GOFLAGS=""
 ARG DEBUG=0

--- a/template/golang-http/main.go
+++ b/template/golang-http/main.go
@@ -3,7 +3,7 @@ package main
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"log"
 	"net/http"
 	"os"
@@ -83,7 +83,7 @@ func makeRequestHandler() func(http.ResponseWriter, *http.Request) {
 		if r.Body != nil {
 			defer r.Body.Close()
 
-			bodyBytes, bodyErr := ioutil.ReadAll(r.Body)
+			bodyBytes, bodyErr := io.ReadAll(r.Body)
 
 			if bodyErr != nil {
 				log.Printf("Error reading body from request.")

--- a/template/golang-middleware/function/handler.go
+++ b/template/golang-middleware/function/handler.go
@@ -2,7 +2,7 @@ package function
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 )
 
@@ -12,7 +12,7 @@ func Handle(w http.ResponseWriter, r *http.Request) {
 	if r.Body != nil {
 		defer r.Body.Close()
 
-		body, _ := ioutil.ReadAll(r.Body)
+		body, _ := io.ReadAll(r.Body)
 
 		input = body
 	}


### PR DESCRIPTION
Signed-off-by: Alex Ellis (OpenFaaS Ltd) <alexellis2@gmail.com>

## Description

Switch to io from ioutil to read body

## How Has This Been Tested?

Tested with local docker build, also enables Go modules as a
default for golang-http, which was missing but meant to be
enabled via #63

Fixes #67

## How are existing users impacted? What migration steps/scripts do we need?

I don't expect an impact.