### PR TITLE
Allow static files to be published into final image for Go template

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,32 @@ You can manage dependencies in one of the following ways:
 - You can also Go modules with vendoring, run `go mod vendor` in your function folder and add `--build-arg GO111MODULE=off --build-arg GOFLAGS='-mod=vendor'` to `faas-cli up`
 - If you have a private module dependency, we recommend using the vendoring technique from above.
 
+## Adding static files to your image
+
+Any folder named `static` will be copied into the final image published for your function.
+
+To read this back at runtime, you can do the following:
+
+```go
+package function
+
+import (
+    "io/ioutil"
+    "net/http"
+)
+
+func Handle(w http.ResponseWriter, r *http.Request) {
+
+    data, err := ioutil.ReadFile("./static/file.txt")
+
+    if err != nil {
+        http.Error(w, err.Error(), http.StatusInternalServerError)
+    }
+
+    w.Write(data)
+}
+```
+
 ## 1.0 golang-http
 
 This template provides additional context and control over the HTTP response from your function.

--- a/template/golang-http/Dockerfile
+++ b/template/golang-http/Dockerfile
@@ -26,8 +26,8 @@ ENV CGO_ENABLED=${CGO_ENABLED}
 # Run a gofmt and exclude all vendored code.
 RUN test -z "$(gofmt -l $(find . -type f -name '*.go' -not -path "./vendor/*" -not -path "./function/vendor/*"))" || { echo "Run \"gofmt -s -w\" on your Golang code"; exit 1; }
 
-
 WORKDIR /go/src/handler/function
+RUN mkdir -p /go/src/handler/function/static
 
 RUN GOOS=${TARGETOS} GOARCH=${TARGETARCH} go test ./... -cover
 
@@ -35,7 +35,7 @@ WORKDIR /go/src/handler
 RUN CGO_ENABLED=${CGO_ENABLED} GOOS=${TARGETOS} GOARCH=${TARGETARCH} \
     go build --ldflags "-s -w" -a -installsuffix cgo -o handler .
 
-FROM --platform=${TARGETPLATFORM:-linux/amd64} alpine:3.14
+FROM --platform=${TARGETPLATFORM:-linux/amd64} alpine:3.15
 # Add non root user and certs
 RUN apk --no-cache add ca-certificates \
     && addgroup -S app && adduser -S -g app app
@@ -46,9 +46,9 @@ RUN mkdir -p /home/app \
 
 WORKDIR /home/app
 
-COPY --from=build --chown=app /go/src/handler/handler    .
-COPY --from=build --chown=app /usr/bin/fwatchdog         .
-COPY --from=build --chown=app /go/src/handler/function/  .
+COPY --from=build --chown=app /go/src/handler/handler           .
+COPY --from=build --chown=app /usr/bin/fwatchdog                .
+COPY --from=build --chown=app /go/src/handler/function/static   static
 
 USER app
 

--- a/template/golang-middleware/Dockerfile
+++ b/template/golang-middleware/Dockerfile
@@ -26,6 +26,7 @@ ENV CGO_ENABLED=${CGO_ENABLED}
 RUN test -z "$(gofmt -l $(find . -type f -name '*.go' -not -path "./vendor/*" -not -path "./function/vendor/*"))" || { echo "Run \"gofmt -s -w\" on your Golang code"; exit 1; }
 
 WORKDIR /go/src/handler/function
+RUN mkdir -p /go/src/handler/function/static
 
 RUN GOOS=${TARGETOS} GOARCH=${TARGETARCH} go test ./... -cover
 
@@ -33,7 +34,8 @@ WORKDIR /go/src/handler
 RUN GOOS=${TARGETOS} GOARCH=${TARGETARCH} \
     go build --ldflags "-s -w" -a -installsuffix cgo -o handler .
 
-FROM --platform=${TARGETPLATFORM:-linux/amd64} alpine:3.14
+FROM --platform=${TARGETPLATFORM:-linux/amd64} alpine:3.15 as ship
+
 # Add non root user and certs
 RUN apk --no-cache add ca-certificates \
     && addgroup -S app && adduser -S -g app app
@@ -44,9 +46,9 @@ RUN mkdir -p /home/app \
 
 WORKDIR /home/app
 
-COPY --from=build --chown=app /go/src/handler/handler    .
-COPY --from=build --chown=app /usr/bin/fwatchdog         .
-COPY --from=build --chown=app /go/src/handler/function/  .
+COPY --from=build --chown=app /go/src/handler/handler           .
+COPY --from=build --chown=app /usr/bin/fwatchdog                .
+COPY --from=build --chown=app /go/src/handler/function/static   static
 
 USER app
 


### PR DESCRIPTION
Signed-off-by: Alex Ellis (OpenFaaS Ltd) <alexellis2@gmail.com>

## Description

Allow static files to be published into final image for Go template

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

```go
package function

import (
    "io/ioutil"
    "net/http"
)

func Handle(w http.ResponseWriter, r *http.Request) {

    data, err := ioutil.ReadFile("./static/file.txt")

    if err != nil {
        http.Error(w, err.Error(), http.StatusInternalServerError)
    }

    w.Write(data)
}
```

## How are existing users impacted? What migration steps/scripts do we need?

This is a *breaking change* for existing users who rely on folder names such as `templates` or `dataset.json` within their published image.

Now, put these files into the `static` folder and read them from `./static/templates/index.html` and so forth.

## Checklist:

A note will be published in the openfaas docs repo for this new change.
