### PR TITLE
chore: add basic template build validation workflow

### DIFF
--- a/.github/workflows/only-ci.yaml
+++ b/.github/workflows/only-ci.yaml
@@ -1,0 +1,23 @@
+name: ci-only
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 1
+      - name: Setup faas-cli
+        run: curl -sSL https://cli.openfaas.com | sh
+      - name: Verify all templates
+        run: bash verify.sh

--- a/verify.sh
+++ b/verify.sh
@@ -1,0 +1,77 @@
+#!/bin/bash
+set -e
+
+CLI="faas-cli"
+
+build_template() {
+    template=$1
+
+    echo Building $template
+    func_name=$template-ci
+    $CLI new $func_name --lang $template 2>/dev/null 1>&2
+    $CLI build -f $func_name.yml
+}
+
+verify_and_clean() {
+    image=$1
+    tag_name=latest
+
+    echo Verifying $template
+    container=$(docker run -d -p 8080:8080 $func_name:$tag_name)
+    sleep 5 # wait for slower templates to start
+    output=$(curl -s -d "testing" http://127.0.0.1:8080)
+
+    echo $image output: $output
+    success=false
+    if [ ! -z "$output" ]; then # output was not empty = good template
+        success=true
+    fi
+
+    echo Cleaning $image
+    docker rm $container -f 2>/dev/null 1>&2
+    docker rmi $func_name:$tag_name 2>/dev/null 1>&2
+
+    if [ "$success" = false ]; then
+        echo $image template failed validation
+        exit 1
+    else
+        echo $image template validation successful
+    fi
+}
+
+if ! [ -x "$(command -v faas-cli)" ]; then
+    HERE=$(pwd)
+    cd /tmp/
+    curl -sSL https://cli.openfaas.com | sh
+    CLI="/tmp/faas-cli"
+
+    cd $HERE
+fi
+
+cli_version=$($CLI version --short-version)
+
+echo Validating templates with faas-cli $cli_version
+
+cd ./template
+
+# verify each of the templates
+for dir in ./*/; do
+    dirname=${dir%*/}
+    template=${dirname##*/}
+
+    # skip arm templates
+    case "$template" in
+    *-arm*) continue ;;
+    esac
+
+    pushd ../ 2>/dev/null 1>&2
+
+    build_template $template
+    verify_and_clean $template
+
+    popd 2>/dev/null 1>&2
+done
+
+# remove the generated files and folders if successful
+cd ../
+rm -rf *-ci *-ci.yml


### PR DESCRIPTION
Implement the basic template build validation from openfaas/templates

This allows us to automate validate that the basic template structure is valid and builds as expected.


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Copied from https://github.com/openfaas/python-flask-template/pull/64

## How are existing users impacted? What migration steps/scripts do we need?
No impact

## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [x] read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] signed-off my commits with `git commit -s`
- [ ] added unit tests
