### PR TITLE
fix: update modules-cleanup.sh

### DIFF
--- a/template/golang-http/modules-cleanup.sh
+++ b/template/golang-http/modules-cleanup.sh
@@ -4,6 +4,8 @@ set -e
 
 GO111MODULE=$(go env GO111MODULE)
 
+[ -z "$DEBUG" ] && DEBUG=0
+
 # move_vendor will copy the function's vendor folder,
 # if it exists.
 move_vendor() {


### PR DESCRIPTION
Signed-off-by: Talha Altınel <talhaaltinel@hotmail.com>

## Description

ditching out sh: out of index message from consoles

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I have tested on my own by doing

`faas-cli template pull https://github.com/openfaas/golang-http-template `
`faas-cli new --lang golang-http cow-fn `
`faas-cli build -f cow-fn.yml`





## How are existing users impacted? What migration steps/scripts do we need?
nothing big deal, just don't like red messages

## Checklist:

I have:

- [X] updated the documentation and/or roadmap (if required)
- [X] read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [X] signed-off my commits with `git commit -s`
- [ ] added unit tests
